### PR TITLE
Fix Rust 1.58 clippy warning

### DIFF
--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -551,8 +551,7 @@ fn container_image(version: &str) -> String {
         // image during restarts depending on the imagePullPolicy.
         // TODO: should be made configurable
         "docker.stackable.tech/stackable/druid:{}-stackable{}",
-        version.to_string(),
-        DEFAULT_IMAGE_VERSION
+        version, DEFAULT_IMAGE_VERSION
     )
 }
 


### PR DESCRIPTION
## Description

Clippy in Rust 1.58 introduced a new warning, this fixes it.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
