### PR TITLE
Removed namespace for zookeeper cluster

### DIFF
--- a/deploy/crd/druidcluster.crd.yaml
+++ b/deploy/crd/druidcluster.crd.yaml
@@ -522,16 +522,8 @@ spec:
                 version:
                   description: Desired Druid version
                   type: string
-                zookeeperReference:
-                  properties:
-                    configMapName:
-                      type: string
-                    namespace:
-                      type: string
-                  required:
-                    - configMapName
-                    - namespace
-                  type: object
+                zookeeperCluster:
+                  type: string
               required:
                 - brokers
                 - coordinators
@@ -541,7 +533,7 @@ spec:
                 - middleManagers
                 - routers
                 - version
-                - zookeeperReference
+                - zookeeperCluster
               type: object
             status:
               nullable: true

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -40,7 +40,7 @@ metadata:
   name: simple-druid
 spec:
   version: 0.22.0
-  zookeeperReference: simple-zk
+  zookeeperCluster: simple-zk
   metadataStorageDatabase:
     dbType: postgresql
     connString: jdbc:postgresql://druid-postgresql/druid

--- a/examples/derby/druidcluster.yaml
+++ b/examples/derby/druidcluster.yaml
@@ -4,9 +4,7 @@ metadata:
   name: derby-druid
 spec:
   version: 0.22.0
-  zookeeperReference:
-    configMapName: simple
-    namespace: default
+  zookeeperCluster: simple
   metadataStorageDatabase:
     dbType: derby
     connString: jdbc:derby://localhost:1527/var/druid/metadata.db;create=true

--- a/examples/psql-s3/druidcluster.yaml
+++ b/examples/psql-s3/druidcluster.yaml
@@ -4,9 +4,7 @@ metadata:
   name: psqls3-druid
 spec:
   version: 0.22.0
-  zookeeperReference:
-    configMapName: simple
-    namespace: default
+  zookeeperCluster: simple
   metadataStorageDatabase:
     dbType: postgresql
     connString: jdbc:postgresql://druid-postgresql/druid

--- a/examples/psql/druidcluster.yaml
+++ b/examples/psql/druidcluster.yaml
@@ -4,9 +4,7 @@ metadata:
   name: psql-druid
 spec:
   version: 0.22.0
-  zookeeperReference:
-    configMapName: simple
-    namespace: default
+  zookeeperCluster: simple
   metadataStorageDatabase:
     dbType: postgresql
     connString: jdbc:postgresql://druid-postgresql/druid

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -83,7 +83,7 @@ pub struct DruidClusterSpec {
     pub metadata_storage_database: DatabaseConnectionSpec,
     pub deep_storage: DeepStorageSpec,
     pub s3: Option<S3Spec>,
-    pub zookeeper_reference: ZookeeperReference,
+    pub zookeeper_cluster: String,
 }
 
 #[derive(
@@ -182,13 +182,6 @@ pub struct DatabaseConnectionSpec {
     pub port: u16,
     pub user: Option<String>,
     pub password: Option<String>,
-}
-
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct ZookeeperReference {
-    pub config_map_name: String,
-    pub namespace: String,
 }
 
 #[derive(
@@ -454,7 +447,7 @@ mod tests {
                 metadata_storage_database: Default::default(),
                 deep_storage: Default::default(),
                 s3: None,
-                zookeeper_reference: Default::default(),
+                zookeeper_cluster: Default::default(),
             },
         );
 


### PR DESCRIPTION
## Description

This PR removes the `namespace` field for the zookeeper reference; i.e. it is now not required to specify a namespace, instead the operator looks for the discovery config map in the same namespace as the druid cluster is.

This is the intended behaviour and also necessary for the kuttl tests to work.

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
