### PR TITLE
[Merged by Bors] - Upgrade Druid to v0.22.1

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -39,7 +39,7 @@ kind: DruidCluster
 metadata:
   name: simple-druid
 spec:
-  version: 0.22.0
+  version: 0.22.1
   zookeeperConfigMapName: simple-zk
   metadataStorageDatabase:
     dbType: postgresql

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -20,9 +20,10 @@ For testing purposes, you can spin up a PostgreSQL database with the bitnami Pos
 And set up the Postgres database:
 
     helm install druid bitnami/postgresql \
-    --set postgresqlUsername=druid \
-    --set postgresqlPassword=druid \
-    --set postgresqlDatabase=druid
+    --version=11 \
+    --set auth.username=druid \
+    --set auth.password=druid \
+    --set auth.database=druid
 
 == Creating a Druid Cluster
 

--- a/docs/modules/ROOT/partials/supported-versions.adoc
+++ b/docs/modules/ROOT/partials/supported-versions.adoc
@@ -2,4 +2,4 @@
 // This is a separate file, since it is used by both the direct Druid documentation, and the overarching
 // Stackable Platform documentation.
 
-- 0.22.0
+- 0.22.1

--- a/examples/derby/druidcluster.yaml
+++ b/examples/derby/druidcluster.yaml
@@ -3,7 +3,7 @@ kind: DruidCluster
 metadata:
   name: derby-druid
 spec:
-  version: 0.22.0
+  version: 0.22.1
   zookeeperConfigMapName: simple
   metadataStorageDatabase:
     dbType: derby

--- a/examples/psql-s3/druidcluster.yaml
+++ b/examples/psql-s3/druidcluster.yaml
@@ -3,7 +3,7 @@ kind: DruidCluster
 metadata:
   name: psqls3-druid
 spec:
-  version: 0.22.0
+  version: 0.22.1
   zookeeperConfigMapName: simple
   metadataStorageDatabase:
     dbType: postgresql

--- a/examples/psql/druidcluster.yaml
+++ b/examples/psql/druidcluster.yaml
@@ -3,7 +3,7 @@ kind: DruidCluster
 metadata:
   name: psql-druid
 spec:
-  version: 0.22.0
+  version: 0.22.1
   zookeeperConfigMapName: simple
   metadataStorageDatabase:
     dbType: postgresql


### PR DESCRIPTION
## Description

This PR updates the docs and examples to use 0.22.1

Also the instructions for installing the Postgres bitnami helm chart have been updated to work with the latest version of the Chart.

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
