### PR TITLE
[Merged by Bors] - Druid Opa Authorizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,21 @@ All notable changes to this project will be documented in this file.
   a single namespace to watch ([#183]).
 - BREAKING: Local backend storage (deep-storage) has been replaced with HDFS-storage, affecting the CRD ([#187]).
 - BREAKING: The corresponding local-storage label has been removed, affecting the CRD ([#124]).
-- Make the inclusion of the druid-s3-extension dependent on the Custom Resource definition ([#71]).
+- Make the inclusion of the druid-s3-extension dependent on the Custom Resource definition ([#192]).
 
 ### Changed
 
 - Many configuration properties are not hardcoded anymore, product-config expanded ([#195])
-- `operator-rs` `0.10.0` -> `0.14.1` ([#178], [#183], [#195]).
+- `operator-rs` `0.10.0` -> `0.15.0` ([#178], [#183], [#195], [#187]).
 - `snafu` `0.6` -> `0.7` ([#178]).
 
-[#195]: https://github.com/stackabletech/druid-operator/pull/195
 [#124]: https://github.com/stackabletech/druid-operator/pull/124
 [#178]: https://github.com/stackabletech/druid-operator/pull/178
 [#183]: https://github.com/stackabletech/druid-operator/pull/183
+[#186]: https://github.com/stackabletech/druid-operator/pull/186
 [#187]: https://github.com/stackabletech/druid-operator/pull/187
-[#71]: https://github.com/stackabletech/druid-operator/issues/71
+[#192]: https://github.com/stackabletech/druid-operator/pull/192
+[#195]: https://github.com/stackabletech/druid-operator/pull/195
 
 ## [0.4.0] - 2022-02-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1551,7 +1551,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "stackable-operator",
- "strum 0.24.0",
+ "strum",
  "tracing",
 ]
 
@@ -1572,7 +1572,7 @@ dependencies = [
  "snafu",
  "stackable-druid-crd",
  "stackable-operator",
- "strum 0.24.0",
+ "strum",
  "tokio",
  "tracing",
 ]
@@ -1580,7 +1580,7 @@ dependencies = [
 [[package]]
 name = "stackable-operator"
 version = "0.14.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.14.1#45104463a311673f62193252c5964b3267a69899"
+source = "git+https://github.com/stackabletech/operator-rs.git?branch=add_opa_config_struct#71992f1e2615eac9e448ab67c970421fe8650f5f"
 dependencies = [
  "backoff",
  "chrono",
@@ -1600,7 +1600,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
- "strum 0.23.0",
+ "strum",
  "thiserror",
  "tokio",
  "tracing",
@@ -1615,33 +1615,11 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "strum"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae14b91c7d11c9a851d3fbc80a963198998c2a64eec840477fa92d8ce9b70bb"
-dependencies = [
- "strum_macros 0.23.1",
-]
-
-[[package]]
-name = "strum"
 version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e96acfc1b70604b8b2f1ffa4c57e59176c7dbb05d556c71ecd2f5498a1dee7f8"
 dependencies = [
- "strum_macros 0.24.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bb0dc7ee9c15cea6199cde9a127fa16a4c5819af85395457ad72d68edc85a38"
-dependencies = [
- "heck 0.3.3",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
+ "strum_macros",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -291,9 +291,9 @@ checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee2626afccd7561a06cf1367e2950c4718ea04565e20fb5029b6c7d8ad09abcf"
+checksum = "21e50f3adc76d6a43f5ed73b698a87d0760ca74617f60f7c3b879003536fdd28"
 
 [[package]]
 name = "either"
@@ -519,7 +519,7 @@ checksum = "d39cd93900197114fa1fcb7ae84ca742095eed9442088988ae74fa744e930e77"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.10.2+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -754,9 +754,9 @@ dependencies = [
 
 [[package]]
 name = "kube"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86835e9147615457c1edc2b11c723acd1d21372e9cefa80a9d2742f6d69042d0"
+checksum = "4dcc72fdf0c491160a34d4a1bfb03f96da8a5054288d61c816d514b5c2fa49ea"
 dependencies = [
  "k8s-openapi",
  "kube-client",
@@ -767,9 +767,9 @@ dependencies = [
 
 [[package]]
 name = "kube-client"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71f8aa916ee8290fbd0af76b3a28093a8786fccb6286902095a5243484447971"
+checksum = "94b01c722d55ffedec74cbc259b4508d8a59bf19540006ec87618f76ab156579"
 dependencies = [
  "base64",
  "bytes",
@@ -795,7 +795,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tower",
  "tower-http",
  "tracing",
@@ -803,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "kube-core"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da41f98f213796a68fcd4510c88b5fd36de131c1ea30d152474c3f2e1bef1a72"
+checksum = "7dd9e3535777edd122cc26fe3fe6357066b33eff63d8b919862edbe7a956a679"
 dependencies = [
  "chrono",
  "form_urlencoded",
@@ -821,9 +821,9 @@ dependencies = [
 
 [[package]]
 name = "kube-derive"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd6fdc2e1615a3aecd7e90fe4bda3ba32379e38193251d4ddaccba26579fe22"
+checksum = "1322e25c20dd6f18ca6baecc88bb130331e99d988df9d7a9a207f15819e05bff"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "kube-runtime"
-version = "0.69.1"
+version = "0.70.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e8bf2258850dbc0a062b561656a1d7020fa8040d552e149f0a0361f0d6794e"
+checksum = "816c8c086f8bbcf9a4db0b7a68db90b784ef6292a57de35c64cccb90d5edfbe5"
 dependencies = [
  "ahash",
  "backoff",
@@ -845,14 +845,14 @@ dependencies = [
  "json-patch",
  "k8s-openapi",
  "kube-client",
- "parking_lot 0.11.2",
+ "parking_lot",
  "pin-project",
  "serde",
  "serde_json",
  "smallvec",
  "thiserror",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util",
  "tracing",
 ]
 
@@ -864,9 +864,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.119"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf2e165bb3457c8e098ea76f3e3bc9db55f87aa90d52d0e6be741470916aaa4"
+checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "libgit2-sys"
@@ -939,14 +939,15 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "mio"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+checksum = "52da4364ffb0e4fe33a9841a98a3f3014fb964045ce4f7a45a398243c8d6b0c9"
 dependencies = [
  "libc",
  "log",
  "miow",
  "ntapi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "winapi",
 ]
 
@@ -1074,37 +1075,12 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1230,9 +1206,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "b4af2ec4714533fcdf07e886f17025ace8b997b9ce51204ee69b6da831c3da57"
 dependencies = [
  "proc-macro2",
 ]
@@ -1278,12 +1254,13 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.4.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528532f3d801c87aec9def2add9ca802fe569e44a544afe633765267840abe64"
+checksum = "7776223e2696f1aa4c6b0170e83212f47296a00424305117d013dfe86fb0fe55"
 dependencies = [
  "getrandom",
  "redox_syscall",
+ "thiserror",
 ]
 
 [[package]]
@@ -1579,8 +1556,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.14.1"
-source = "git+https://github.com/stackabletech/operator-rs.git?branch=add_opa_config_struct#71992f1e2615eac9e448ab67c970421fe8650f5f"
+version = "0.15.0"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.15.0#c7c408d476c0b7ba06833c19e5c9d2aefa5875ae"
 dependencies = [
  "backoff",
  "chrono",
@@ -1637,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.86"
+version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a65b3f4ffa0092e9887669db0eae07941f023991ab58ea44da8fe8e2d511c6b"
+checksum = "ea297be220d52398dcc07ce15a209fce436d361735ac1db700cab3b6cdfb9f54"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1741,7 +1718,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1782,21 +1759,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.6.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "pin-project-lite",
- "slab",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64910e1b9c1901aaf5375561e35b9c057d95ff41a44ede043a03e09279eabaf1"
@@ -1806,6 +1768,7 @@ dependencies = [
  "futures-sink",
  "log",
  "pin-project-lite",
+ "slab",
  "tokio",
 ]
 
@@ -1829,7 +1792,7 @@ dependencies = [
  "pin-project",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.0",
+ "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1837,9 +1800,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90c125fdea84614a4368fd35786b51d0682ab8d42705e061e92f0b955dea40fb"
+checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
 dependencies = [
  "base64",
  "bitflags",
@@ -2019,6 +1982,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2078,6 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50344758e2f40e3a1fcfc8f6f91aa57b5f8ebd8d27919fe6451f15aaaf9ee608"
+checksum = "7eb5728b8afd3f280a869ce1d4c554ffaed35f45c231fc41bfbd0381bef50317"

--- a/deploy/crd/druidcluster.crd.yaml
+++ b/deploy/crd/druidcluster.crd.yaml
@@ -418,10 +418,16 @@ spec:
                   required:
                     - roleGroups
                   type: object
-                opaConfigMapName:
-                  type: string
-                opaDruidApiPath:
-                  type: string
+                opa:
+                  properties:
+                    opaConfigMapName:
+                      type: string
+                    opaDruidApiPath:
+                      type: string
+                  required:
+                    - opaConfigMapName
+                    - opaDruidApiPath
+                  type: object
                 routers:
                   properties:
                     cliOverrides:
@@ -535,8 +541,7 @@ spec:
                 - historicals
                 - metadataStorageDatabase
                 - middleManagers
-                - opaConfigMapName
-                - opaDruidApiPath
+                - opa
                 - routers
                 - version
                 - zookeeperConfigMapName

--- a/deploy/crd/druidcluster.crd.yaml
+++ b/deploy/crd/druidcluster.crd.yaml
@@ -418,6 +418,10 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                opaConfigMapName:
+                  type: string
+                opaDruidApiPath:
+                  type: string
                 routers:
                   properties:
                     cliOverrides:
@@ -531,6 +535,8 @@ spec:
                 - historicals
                 - metadataStorageDatabase
                 - middleManagers
+                - opaConfigMapName
+                - opaDruidApiPath
                 - routers
                 - version
                 - zookeeperConfigMapName

--- a/deploy/crd/druidcluster.crd.yaml
+++ b/deploy/crd/druidcluster.crd.yaml
@@ -416,13 +416,13 @@ spec:
                 opa:
                   nullable: true
                   properties:
-                    opaConfigMapName:
+                    configMapName:
                       type: string
-                    opaDruidApiPath:
+                    package:
+                      nullable: true
                       type: string
                   required:
-                    - opaConfigMapName
-                    - opaDruidApiPath
+                    - configMapName
                   type: object
                 routers:
                   properties:

--- a/deploy/crd/druidcluster.crd.yaml
+++ b/deploy/crd/druidcluster.crd.yaml
@@ -419,6 +419,7 @@ spec:
                     - roleGroups
                   type: object
                 opa:
+                  nullable: true
                   properties:
                     opaConfigMapName:
                       type: string
@@ -541,7 +542,6 @@ spec:
                 - historicals
                 - metadataStorageDatabase
                 - middleManagers
-                - opa
                 - routers
                 - version
                 - zookeeperConfigMapName

--- a/deploy/helm/druid-operator/crds/crds.yaml
+++ b/deploy/helm/druid-operator/crds/crds.yaml
@@ -415,6 +415,17 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                opa:
+                  nullable: true
+                  properties:
+                    configMapName:
+                      type: string
+                    package:
+                      nullable: true
+                      type: string
+                  required:
+                    - configMapName
+                  type: object
                 routers:
                   properties:
                     cliOverrides:

--- a/deploy/manifests/crds.yaml
+++ b/deploy/manifests/crds.yaml
@@ -417,6 +417,17 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                opa:
+                  nullable: true
+                  properties:
+                    configMapName:
+                      type: string
+                    package:
+                      nullable: true
+                      type: string
+                  required:
+                    - configMapName
+                  type: object
                 routers:
                   properties:
                     cliOverrides:

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -125,8 +125,46 @@ This allows to ingest data from accessible buckets already. To configure a bucke
 deepStorage:
   storageType: s3
   bucket: druid-deepstorage
-  baseKey: storage           # the base key is the prefix to be used; optional
+  baseKey: storage <1>
 ----
+<1> The base key is the prefix to be used; optional
+
+== Using Open Policy Agent (OPA) for Authorization
+
+Druid can connect to an Open Policy Agent (OPA) instance for authorization policy decisions. You need to run an OPA instance to connect to, for which we refer to the https://docs.stackable.tech/opa/index.html[OPA Operator docs]. How you can write RegoRules for Druid is explained <<_defining_regorules, below>>.
+
+Once you have defined your rules, you need to configure the OPA cluster name and endpoint to use for Druid authorization requests. Add a section to the `spec` for OPA:
+
+[source,yaml]
+----
+opa:
+  opaConfigMapName: simple-opa <1>
+  opaDruidApiPath: v1/data/druid/allow <2>
+----
+<1> The name of your OPA cluster (`simple-opa` in this case)
+<2> The resource to request. If you created a package `druid` and a rule `allow` in that package that you want to use, the resource becomes `v1/data/druid/allow`.
+
+=== Defining RegoRules
+
+For a general explanation of how rules are written, we refer to the https://www.openpolicyagent.org/docs/latest/#rego[OPA documentation]. Inside your rule you will have access to input from Druid. Druid provides this data to you to base your policy decisions on:
+
+[source,json]
+----
+{
+  "user": "someUsername", <1>
+  "action": "READ", <2>
+  "resource": {
+    "type": "DATASOURCE", <3>
+    "name": "myTable" <4>
+  }
+}
+----
+<1> The authenticated identity of the user that wants to perform the action
+<2> The action type, can be either `READ` or `WRITE`.
+<3> The resource type, one of `STATE`, `CONFIG` and `DATASOURCE`.
+<4> In case of a datasource this is the table name, for `STATE` this will simply be `STATE`, the same for `CONFIG`.
+
+For more details consult the https://druid.apache.org/docs/latest/operations/security-user-auth.html#authentication-and-authorization-model[Druid Authentication and Authorization Model].
 
 == Connecting to Druid from other Services
 

--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -140,11 +140,11 @@ Once you have defined your rules, you need to configure the OPA cluster name and
 [source,yaml]
 ----
 opa:
-  opaConfigMapName: simple-opa <1>
-  opaDruidApiPath: v1/data/druid/allow <2>
+  configMapName: simple-opa <1>
+  package: my-druid-rules <2>
 ----
 <1> The name of your OPA cluster (`simple-opa` in this case)
-<2> The resource to request. If you created a package `druid` and a rule `allow` in that package that you want to use, the resource becomes `v1/data/druid/allow`.
+<2> The RegoRule package to use for policy decisions. The package should contain an `allow` rule. This is optional and will default to the name of the Druid cluster.
 
 === Defining RegoRules
 

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/stackabletech/druid-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
+# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_opa_config_struct" }
 
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/stackabletech/druid-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_opa_config_struct" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -346,7 +346,7 @@ impl Configuration for DruidConfig {
                         AUTH_AUTHORIZER_OPA_TYPE.to_string(),
                         Some(AUTH_AUTHORIZER_OPA_TYPE_VALUE.to_string()),
                     );
-                    // The opaUri still needs to be set, but that is done later
+                    // The opaUri still needs to be set, but that requires a discovery config map and is handled in the druid_controller.rs
                 }
                 // deep storage
                 let ds = &resource.spec.deep_storage;

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -33,9 +33,12 @@ pub const EXT_DATASKETCHES: &str = "druid-datasketches";
 pub const PROMETHEUS_EMITTER: &str = "prometheus-emitter";
 pub const EXT_PSQL_MD_ST: &str = "postgresql-metadata-storage";
 pub const EXT_MYSQL_MD_ST: &str = "mysql-metadata-storage";
+pub const EXT_OPA_AUTHORIZER: &str = "druid-opa-authorizer";
+pub const EXT_BASIC_SECURITY: &str = "druid-basic-security";
 // zookeeper
 pub const ZOOKEEPER_CONNECTION_STRING: &str = "druid.zk.service.host";
-// deep storage
+pub const OPA_CONNECTION_STRING: &str = "druid.auth.authorizer.MyBasicMetadataAuthorizer.opaUri"; // TODO here the name is hardcoded! problematic
+                                                                                                  // deep storage
 pub const DS_TYPE: &str = "druid.storage.type";
 // S3
 pub const DS_BUCKET: &str = "druid.storage.bucket";
@@ -84,6 +87,8 @@ pub struct DruidClusterSpec {
     pub deep_storage: DeepStorageSpec,
     pub s3: Option<S3Spec>,
     pub zookeeper_config_map_name: String,
+    pub opa_config_map_name: String,
+    pub opa_druid_api_path: String,
 }
 
 #[derive(
@@ -310,6 +315,8 @@ impl Configuration for DruidConfig {
                     String::from(EXT_DATASKETCHES),
                     String::from(PROMETHEUS_EMITTER),
                     String::from(EXT_S3),
+                    String::from(EXT_BASIC_SECURITY),
+                    String::from(EXT_OPA_AUTHORIZER),
                 ];
                 // metadata storage
                 let mds = &resource.spec.metadata_storage_database;
@@ -448,6 +455,7 @@ mod tests {
                 deep_storage: Default::default(),
                 s3: None,
                 zookeeper_config_map_name: Default::default(),
+                opa_config_map_name: Default::default(),
             },
         );
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -252,13 +252,6 @@ pub struct S3Spec {
     pub endpoint: Option<String>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct OpaSpec {
-    pub opa_config_map_name: String,
-    pub opa_druid_api_path: String,
-}
-
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Default)]
 #[serde(rename_all = "camelCase")]
 pub struct DruidConfig {}

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -37,7 +37,6 @@ pub const EXT_OPA_AUTHORIZER: &str = "druid-opa-authorizer";
 pub const EXT_BASIC_SECURITY: &str = "druid-basic-security";
 // zookeeper
 pub const ZOOKEEPER_CONNECTION_STRING: &str = "druid.zk.service.host";
-pub const OPA_CONNECTION_STRING: &str = "druid.auth.authorizer.OpaAuthorizer.opaUri";
 // deep storage
 pub const DS_TYPE: &str = "druid.storage.type";
 // S3
@@ -87,7 +86,7 @@ pub struct DruidClusterSpec {
     pub deep_storage: DeepStorageSpec,
     pub s3: Option<S3Spec>,
     pub zookeeper_config_map_name: String,
-    pub opa: OpaSpec,
+    pub opa: Option<OpaSpec>,
 }
 
 #[derive(

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -37,8 +37,8 @@ pub const EXT_OPA_AUTHORIZER: &str = "druid-opa-authorizer";
 pub const EXT_BASIC_SECURITY: &str = "druid-basic-security";
 // zookeeper
 pub const ZOOKEEPER_CONNECTION_STRING: &str = "druid.zk.service.host";
-pub const OPA_CONNECTION_STRING: &str = "druid.auth.authorizer.MyBasicMetadataAuthorizer.opaUri"; // TODO here the name is hardcoded! problematic
-                                                                                                  // deep storage
+pub const OPA_CONNECTION_STRING: &str = "druid.auth.authorizer.OpaAuthorizer.opaUri";
+// deep storage
 pub const DS_TYPE: &str = "druid.storage.type";
 // S3
 pub const DS_BUCKET: &str = "druid.storage.bucket";
@@ -87,8 +87,7 @@ pub struct DruidClusterSpec {
     pub deep_storage: DeepStorageSpec,
     pub s3: Option<S3Spec>,
     pub zookeeper_config_map_name: String,
-    pub opa_config_map_name: String,
-    pub opa_druid_api_path: String,
+    pub opa: OpaSpec,
 }
 
 #[derive(
@@ -264,6 +263,13 @@ pub struct DeepStorageSpec {
 pub struct S3Spec {
     pub credentials_secret: String,
     pub endpoint: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OpaSpec {
+    pub opa_config_map_name: String,
+    pub opa_druid_api_path: String,
 }
 
 #[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize, Default)]

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1,9 +1,9 @@
 use serde::{Deserialize, Serialize};
 use stackable_operator::{
     kube::CustomResource,
+    opa::OpaConfig,
     product_config_utils::{ConfigError, Configuration},
     role_utils::Role,
-    opa::OpaConfig,
     schemars::{self, JsonSchema},
 };
 use std::collections::BTreeMap;
@@ -345,8 +345,14 @@ impl Configuration for DruidConfig {
                 }
                 // OPA
                 if let Some(_opa) = &resource.spec.opa {
-                    result.insert(AUTH_AUTHORIZERS.to_string(), Some(AUTH_AUTHORIZERS_VALUE.to_string()));
-                    result.insert(AUTH_AUTHORIZER_OPA_TYPE.to_string(), Some(AUTH_AUTHORIZER_OPA_TYPE_VALUE.to_string()));
+                    result.insert(
+                        AUTH_AUTHORIZERS.to_string(),
+                        Some(AUTH_AUTHORIZERS_VALUE.to_string()),
+                    );
+                    result.insert(
+                        AUTH_AUTHORIZER_OPA_TYPE.to_string(),
+                        Some(AUTH_AUTHORIZER_OPA_TYPE_VALUE.to_string()),
+                    );
                     // The opaUri still needs to be set, but that is done later
                 }
                 // deep storage

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/stackabletech/druid-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_opa_config_struct" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 stackable-druid-crd = { path = "../crd" }
 anyhow = "1.0"
 clap = "3.1"
@@ -27,6 +26,5 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_opa_config_struct" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.15.0" }
 stackable-druid-crd = { path = "../crd" }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/stackabletech/druid-operator"
 version = "0.6.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
+# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_opa_config_struct" }
 stackable-druid-crd = { path = "../crd" }
 anyhow = "1.0"
 clap = "3.1"
@@ -26,5 +27,6 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
+# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", branch = "add_opa_config_struct" }
 stackable-druid-crd = { path = "../crd" }

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -79,36 +79,9 @@ pub fn get_runtime_properties(
     druid.emitter.prometheus.strategy=exporter
     druid.emitter.prometheus.namespace=druid
 
-    # Druid basic security
-    druid.auth.authenticatorChain=[\"MyBasicMetadataAuthenticator\"]
-    druid.auth.authenticator.MyBasicMetadataAuthenticator.type=basic
-    
-    # Default password for 'admin' user, should be changed for production.
-    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialAdminPassword=password1
-    
-    # Default password for internal 'druid_system' user, should be changed for production.
-    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialInternalClientPassword=password2
-    
-    # Uses the metadata store for storing users, you can use authentication API to create new users and grant permissions
-    druid.auth.authenticator.MyBasicMetadataAuthenticator.credentialsValidator.type=metadata
-    
-    # If true and the request credential doesn't exists in this credentials store, the request will proceed to next Authenticator in the chain.
-    druid.auth.authenticator.MyBasicMetadataAuthenticator.skipOnFailure=false
-    
-    druid.auth.authenticator.MyBasicMetadataAuthenticator.authorizerName=MyBasicMetadataAuthorizer
-    
-    # Escalator
-    druid.escalator.type=basic
-    druid.escalator.internalClientUsername=druid_system
-    druid.escalator.internalClientPassword=password2
-    druid.escalator.authorizerName=MyBasicMetadataAuthorizer
-    
-    druid.auth.authorizers=[\"MyBasicMetadataAuthorizer\"]
-    
-     # now 'opa', was 'basic'
-    druid.auth.authorizer.MyBasicMetadataAuthorizer.type=opa
-    druid.auth.authorizer.MyBasicMetadataAuthorizer.opaUri=http://localhost:8181/v1/data/app/druid/allow
-
+    # OPA Authorizer. opaUri is set from the custom resource
+    druid.auth.authorizers=[\"OpaAuthorizer\"]
+    druid.auth.authorizer.OpaAuthorizer.type=opa
     ";
 
     let ports = format!(

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -78,6 +78,37 @@ pub fn get_runtime_properties(
     druid.emitter=prometheus
     druid.emitter.prometheus.strategy=exporter
     druid.emitter.prometheus.namespace=druid
+
+    # Druid basic security
+    druid.auth.authenticatorChain=[\"MyBasicMetadataAuthenticator\"]
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.type=basic
+    
+    # Default password for 'admin' user, should be changed for production.
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialAdminPassword=password1
+    
+    # Default password for internal 'druid_system' user, should be changed for production.
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.initialInternalClientPassword=password2
+    
+    # Uses the metadata store for storing users, you can use authentication API to create new users and grant permissions
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.credentialsValidator.type=metadata
+    
+    # If true and the request credential doesn't exists in this credentials store, the request will proceed to next Authenticator in the chain.
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.skipOnFailure=false
+    
+    druid.auth.authenticator.MyBasicMetadataAuthenticator.authorizerName=MyBasicMetadataAuthorizer
+    
+    # Escalator
+    druid.escalator.type=basic
+    druid.escalator.internalClientUsername=druid_system
+    druid.escalator.internalClientPassword=password2
+    druid.escalator.authorizerName=MyBasicMetadataAuthorizer
+    
+    druid.auth.authorizers=[\"MyBasicMetadataAuthorizer\"]
+    
+     # now 'opa', was 'basic'
+    druid.auth.authorizer.MyBasicMetadataAuthorizer.type=opa
+    druid.auth.authorizer.MyBasicMetadataAuthorizer.opaUri=http://localhost:8181/v1/data/app/druid/allow
+
     ";
 
     let ports = format!(

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -172,9 +172,9 @@ pub async fn reconcile_druid(
         })?;
 
     // Add the API path to the end
-    let opa_connstr = opa_host.trim_end_matches("/").to_owned()
+    let opa_connstr = opa_host.trim_end_matches('/').to_owned()
         + "/"
-        + &druid.spec.opa.opa_druid_api_path.trim_start_matches("/");
+        + druid.spec.opa.opa_druid_api_path.trim_start_matches('/');
 
     let mut roles = HashMap::new();
 

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -106,18 +106,12 @@ pub enum Error {
         cm_name
     ))]
     MissingZookeeperConnString { cm_name: String },
-    #[snafu(display(
-    "Failed to get OPA discovery config map for cluster: {}",
-    cm_name
-    ))]
+    #[snafu(display("Failed to get OPA discovery config map for cluster: {}", cm_name))]
     GetOpaConnStringConfigMap {
         source: stackable_operator::error::Error,
         cm_name: String,
     },
-    #[snafu(display(
-    "Failed to get OPA connection string from config map {}",
-    cm_name
-    ))]
+    #[snafu(display("Failed to get OPA connection string from config map {}", cm_name))]
     MissingOpaConnString { cm_name: String },
     #[snafu(display("Failed to transform configs"))]
     ProductConfigTransform {
@@ -178,7 +172,8 @@ pub async fn reconcile_druid(
         })?;
 
     // Add the API path to the end
-    let opa_connstr = opa_host.trim_end_matches("/").to_owned() + "/"
+    let opa_connstr = opa_host.trim_end_matches("/").to_owned()
+        + "/"
         + &druid.spec.opa.opa_druid_api_path.trim_start_matches("/");
 
     let mut roles = HashMap::new();


### PR DESCRIPTION
## Description

This PR relies on a number of other parts listed down below. In the operator, changes were made to make use of a new OPA authorizer extension for druid.

Parts:
- The Druid OPA Authorizer extension: https://github.com/stackabletech/druid-opa-authorizer - Needs to be compiled and added to the docker image
- The Druid Docker image https://github.com/stackabletech/docker-images/pull/58 needs and update too, to include the new extension
- The operator itself (this PR) needs to be able to configure the new extension
- The integration tests: https://github.com/stackabletech/integration-tests/pull/164 a new integration test was added to test the authorization extension

fixes #145 

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [x] Code contains useful comments
- [x] (Integration-)Test cases added (or not applicable)
- [x] Documentation added (or not applicable)
- [x] Changelog updated (or not applicable)
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
