### PR TITLE
[Merged by Bors] - Remove the hardcoded config properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,9 +15,11 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
+- Many configuration properties are not hardcoded anymore ([#195])
 - `operator-rs` `0.10.0` -> `0.13.0` ([#178],[#183]).
 - `snafu` `0.6` -> `0.7` ([#178]).
 
+[#195]: https://github.com/stackabletech/druid-operator/pull/195
 [#124]: https://github.com/stackabletech/druid-operator/pull/124
 [#178]: https://github.com/stackabletech/druid-operator/pull/178
 [#183]: https://github.com/stackabletech/druid-operator/pull/183

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 
 - Many configuration properties are not hardcoded anymore, product-config expanded ([#195])
-- `operator-rs` `0.10.0` -> `0.13.0` ([#178],[#183]).
+- `operator-rs` `0.10.0` -> `0.14.1` ([#178], [#183], [#195]).
 - `snafu` `0.6` -> `0.7` ([#178]).
 
 [#195]: https://github.com/stackabletech/druid-operator/pull/195

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Changed
 
-- Many configuration properties are not hardcoded anymore ([#195])
+- Many configuration properties are not hardcoded anymore, product-config expanded ([#195])
 - `operator-rs` `0.10.0` -> `0.13.0` ([#178],[#183]).
 - `snafu` `0.6` -> `0.7` ([#178]).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1214,8 +1214,8 @@ dependencies = [
 
 [[package]]
 name = "product-config"
-version = "0.4.0-nightly"
-source = "git+https://github.com/stackabletech/product-config.git?branch=feature/fancy-regex#568c9bcabc283393163b1ca4404174f36f167ccc"
+version = "0.3.1"
+source = "git+https://github.com/stackabletech/product-config.git?tag=0.3.1#40c93e5283beef100c9fecdb6368f1e1480db3e8"
 dependencies = [
  "fancy-regex",
  "java-properties",
@@ -1579,7 +1579,8 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.14.0"
+version = "0.14.1"
+source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.14.1#45104463a311673f62193252c5964b3267a69899"
 dependencies = [
  "backoff",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
+name = "bit-set"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e11e16035ea35e4e5997b393eacbf6f63983188f7a2ad25bfb13465f5ad59de"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,6 +364,16 @@ name = "encoding_index_tests"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
+
+[[package]]
+name = "fancy-regex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95b4efe5be9104a4a18a9916e86654319895138be727b229820c39257c30dda"
+dependencies = [
+ "bit-set",
+ "regex",
+]
 
 [[package]]
 name = "fastrand"
@@ -1189,11 +1214,11 @@ dependencies = [
 
 [[package]]
 name = "product-config"
-version = "0.3.0"
-source = "git+https://github.com/stackabletech/product-config.git?tag=0.3.0#602e7b8e1c235dd93fb3289662c1200eaa1a83db"
+version = "0.4.0-nightly"
+source = "git+https://github.com/stackabletech/product-config.git?branch=feature/fancy-regex#568c9bcabc283393163b1ca4404174f36f167ccc"
 dependencies = [
+ "fancy-regex",
  "java-properties",
- "regex",
  "schemars",
  "semver",
  "serde",
@@ -1554,8 +1579,7 @@ dependencies = [
 
 [[package]]
 name = "stackable-operator"
-version = "0.13.0"
-source = "git+https://github.com/stackabletech/operator-rs.git?tag=0.13.0#401f4053d8c32d0fcd507d94799956181f66105d"
+version = "0.14.0"
 dependencies = [
  "backoff",
  "chrono",

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -141,6 +141,78 @@ properties:
           required: false
       asOfVersion: "0.0.0"
 
+  - property: &indexerLogsDirectory
+      propertyNames:
+        - name: "druid.indexer.logs.directory"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "/stackable/var/druid/indexing-logs"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &processingTmpDir
+      propertyNames:
+        - name: "druid.processing.tmpDir"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "/stackable/var/druid/processing"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerTaskHadoopWorkingPath
+      propertyNames:
+        - name: "druid.indexer.task.hadoopWorkingPath"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "/stackable/var/druid/hadoop-tmp"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
 ###################################################################################################
 # jvm.config
 ###################################################################################################

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -13,6 +13,168 @@ spec:
 
 properties:
 
+  - property: &plaintext
+      propertyNames:
+        - name: "druid.plaintext"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "integer"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &startupLoggingLogProperties
+      propertyNames:
+        - name: "druid.startup.logging.logProperties"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &monitoringMonitors
+      propertyNames:
+        - name: "druid.monitoring.monitors"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "[\"org.apache.druid.java.util.metrics.JvmMonitor\"]"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &emitter
+      propertyNames:
+        - name: "druid.emitter"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "prometheus"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &emitterPrometheusStrategy
+      propertyNames:
+        - name: "druid.emitter.prometheus.strategy"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "exporter"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &emitterPrometheusNamespace
+      propertyNames:
+        - name: "druid.emitter.prometheus.namespace"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "druid"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &emitterPrometheusPort
+      propertyNames:
+        - name: "druid.emitter.prometheus.port"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "integer"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
   - property: &metadataStorageType
       propertyNames:
         - name: "druid.metadata.storage.type"

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -6,9 +6,13 @@ spec:
         regex: "^/|(/[\\w-]+)+$"
         examples:
           - "/tmp/xyz"
+    - unit: &unitPort
+        name: "port"
+        regex: "^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
 
 ###################################################################################################
 # runtime.properties
+# For information on the properties, see: https://druid.apache.org/docs/latest/configuration/index.html
 ###################################################################################################
 
 properties:
@@ -21,6 +25,9 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "integer"
+        min: "1"
+        max: "65535"
+        unit: *unitPort
       roles:
         - name: "broker"
           required: true
@@ -93,6 +100,12 @@ properties:
       defaultValues:
         - fromVersion: "0.0.0"
           value: "prometheus"
+      allowedValues:
+        - "noop"
+        - "logging"
+        - "http"
+        - "parametrized"
+        - "composing"
       roles:
         - name: "broker"
           required: true

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -9,6 +9,14 @@ spec:
     - unit: &unitPort
         name: "port"
         regex: "^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
+    - unit: &unitPrometheusNamespace
+        name: "prometheusNamespace"
+        regex: "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
+    - unit: &unitDuration
+        name: "duration"
+        regex: "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$"
+        examples:
+          - "PT300S"
 
 ###################################################################################################
 # runtime.properties
@@ -131,6 +139,9 @@ properties:
       defaultValues:
         - fromVersion: "0.0.0"
           value: "exporter"
+      allowedValues:
+        - "exporter"
+        - "pushgateway"
       roles:
         - name: "broker"
           required: true
@@ -152,6 +163,7 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+        unit: *unitPrometheusNamespace
       defaultValues:
         - fromVersion: "0.0.0"
           value: "druid"
@@ -176,6 +188,9 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "integer"
+        min: "1"
+        max: "65535"
+        unit: *unitPort
       roles:
         - name: "broker"
           required: true
@@ -197,6 +212,10 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+      allowedValues:
+        - "mysql"
+        - "postgresql"
+        - "derby"
       roles:
         - name: "broker"
           required: true
@@ -262,6 +281,7 @@ properties:
         type: "integer"
         min: "1024"
         max: "65535"
+        unit: *unitPort
       roles:
         - name: "broker"
           required: true
@@ -325,6 +345,7 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+        unit: *unitDirectory
       defaultValues:
         - fromVersion: "0.0.0"
           value: "/stackable/var/druid/indexing-logs"
@@ -349,6 +370,7 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+        unit: *unitDirectory
       defaultValues:
         - fromVersion: "0.0.0"
           value: "/stackable/var/druid/processing"
@@ -373,6 +395,7 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+        unit: *unitDirectory
       defaultValues:
         - fromVersion: "0.0.0"
           value: "/stackable/var/druid/hadoop-tmp"
@@ -397,6 +420,7 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+        unit: *unitDirectory
       defaultValues:
         - fromVersion: "0.0.0"
           value: "/stackable/var/druid/task"
@@ -542,6 +566,7 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+        unit: *unitDuration
       defaultValues:
         - fromVersion: "0.0.0"
           value: "PT20S"
@@ -566,6 +591,7 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+        unit: *unitDuration
       defaultValues:
         - fromVersion: "0.0.0"
           value: "PT20S"
@@ -590,6 +616,10 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+      allowedValues:
+        - "local"
+        - "remote"
+        - "httpRemote"
       defaultValues:
         - fromVersion: "0.0.0"
           value: "remote"
@@ -614,6 +644,9 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+      allowedValues:
+        - "local"
+        - "metadata"
       defaultValues:
         - fromVersion: "0.0.0"
           value: "metadata"
@@ -638,6 +671,7 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+        unit: *unitDuration
       defaultValues:
         - fromVersion: "0.0.0"
           value: "PT20S"

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -106,6 +106,7 @@ properties:
         - "http"
         - "parametrized"
         - "composing"
+        - "prometheus"
       roles:
         - name: "broker"
           required: true
@@ -695,6 +696,30 @@ properties:
           required: false
         - name: "historical"
           required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &coordinatorAsOverlordOverlordService
+      propertyNames:
+        - name: "druid.coordinator.asOverlord.overlordService"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "druid/overlord"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
         - name: "middleManager"
           required: false
         - name: "router"

--- a/deploy/config-spec/properties.yaml
+++ b/deploy/config-spec/properties.yaml
@@ -213,6 +213,319 @@ properties:
           required: false
       asOfVersion: "0.0.0"
 
+  - property: &indexerTaskBaseTaskDir
+      propertyNames:
+        - name: "druid.indexer.task.baseTaskDir"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "/stackable/var/druid/task"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerRunnerJavaOpts
+      propertyNames:
+        - name: "druid.indexer.runner.javaOpts"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "-server -Xms256m -Xmx256m -XX:MaxDirectMemorySize=300m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &routerManagementProxyEnabled
+      propertyNames:
+        # Management proxy to coordinator / overlord: required for unified web console.
+        - name: "druid.router.managementProxy.enabled"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &routerHttpNumConnections
+      propertyNames:
+        - name: "druid.router.http.numConnections"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "integer"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "25"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &historicalCacheUseCache
+      propertyNames:
+        - name: "druid.historical.cache.useCache"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &historicalCachePopulateCache
+      propertyNames:
+        - name: "druid.historical.cache.populateCache"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &coordinatorStartDelay
+      propertyNames:
+        - name: "druid.coordinator.startDelay"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "PT20S"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerQueueStartDelay
+      propertyNames:
+        - name: "druid.indexer.queue.startDelay"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "PT20S"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerRunnerType
+      propertyNames:
+        - name: "druid.indexer.runner.type"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "remote"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerStorageType
+      propertyNames:
+        - name: "druid.indexer.storage.type"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "metadata"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &coordinatorPeriod
+      propertyNames:
+        - name: "druid.coordinator.period"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "PT20S"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &coordinatorAsOverlordEnabled
+      propertyNames:
+        - name: "druid.coordinator.asOverlord.enabled"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &segmentCacheLocations
+      propertyNames:
+        - name: "druid.segmentCache.locations"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "[{\"path\":\"/stackable/var/druid/segment-cache\",\"maxSize\":\"300g\"}]"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
 ###################################################################################################
 # jvm.config
 ###################################################################################################

--- a/deploy/helm/druid-operator/configs/properties.yaml
+++ b/deploy/helm/druid-operator/configs/properties.yaml
@@ -6,12 +6,203 @@ spec:
         regex: "^/|(/[\\w-]+)+$"
         examples:
           - "/tmp/xyz"
+    - unit: &unitPort
+        name: "port"
+        regex: "^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$"
+    - unit: &unitPrometheusNamespace
+        name: "prometheusNamespace"
+        regex: "^[a-zA-Z_:][a-zA-Z0-9_:]*$"
+    - unit: &unitDuration
+        name: "duration"
+        regex: "^P(?!$)(\\d+Y)?(\\d+M)?(\\d+W)?(\\d+D)?(T(?=\\d)(\\d+H)?(\\d+M)?(\\d+S)?)?$"
+        examples:
+          - "PT300S"
 
 ###################################################################################################
 # runtime.properties
+# For information on the properties, see: https://druid.apache.org/docs/latest/configuration/index.html
 ###################################################################################################
 
 properties:
+
+  - property: &plaintext
+      propertyNames:
+        - name: "druid.plaintext"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "integer"
+        min: "1"
+        max: "65535"
+        unit: *unitPort
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &startupLoggingLogProperties
+      propertyNames:
+        - name: "druid.startup.logging.logProperties"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &monitoringMonitors
+      propertyNames:
+        - name: "druid.monitoring.monitors"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "[\"org.apache.druid.java.util.metrics.JvmMonitor\"]"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &emitter
+      propertyNames:
+        - name: "druid.emitter"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "prometheus"
+      allowedValues:
+        - "noop"
+        - "logging"
+        - "http"
+        - "parametrized"
+        - "composing"
+        - "prometheus"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &emitterPrometheusStrategy
+      propertyNames:
+        - name: "druid.emitter.prometheus.strategy"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "exporter"
+      allowedValues:
+        - "exporter"
+        - "pushgateway"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &emitterPrometheusNamespace
+      propertyNames:
+        - name: "druid.emitter.prometheus.namespace"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+        unit: *unitPrometheusNamespace
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "druid"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &emitterPrometheusPort
+      propertyNames:
+        - name: "druid.emitter.prometheus.port"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "integer"
+        min: "1"
+        max: "65535"
+        unit: *unitPort
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
 
   - property: &metadataStorageType
       propertyNames:
@@ -21,6 +212,10 @@ properties:
             file: "runtime.properties"
       datatype:
         type: "string"
+      allowedValues:
+        - "mysql"
+        - "postgresql"
+        - "derby"
       roles:
         - name: "broker"
           required: true
@@ -86,6 +281,7 @@ properties:
         type: "integer"
         min: "1024"
         max: "65535"
+        unit: *unitPort
       roles:
         - name: "broker"
           required: true
@@ -133,6 +329,429 @@ properties:
           required: false
         - name: "coordinator"
           required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerLogsDirectory
+      propertyNames:
+        - name: "druid.indexer.logs.directory"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+        unit: *unitDirectory
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "/stackable/var/druid/indexing-logs"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &processingTmpDir
+      propertyNames:
+        - name: "druid.processing.tmpDir"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+        unit: *unitDirectory
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "/stackable/var/druid/processing"
+      roles:
+        - name: "broker"
+          required: true
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerTaskHadoopWorkingPath
+      propertyNames:
+        - name: "druid.indexer.task.hadoopWorkingPath"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+        unit: *unitDirectory
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "/stackable/var/druid/hadoop-tmp"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerTaskBaseTaskDir
+      propertyNames:
+        - name: "druid.indexer.task.baseTaskDir"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+        unit: *unitDirectory
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "/stackable/var/druid/task"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerRunnerJavaOpts
+      propertyNames:
+        - name: "druid.indexer.runner.javaOpts"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "-server -Xms256m -Xmx256m -XX:MaxDirectMemorySize=300m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: true
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &routerManagementProxyEnabled
+      propertyNames:
+        # Management proxy to coordinator / overlord: required for unified web console.
+        - name: "druid.router.managementProxy.enabled"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &routerHttpNumConnections
+      propertyNames:
+        - name: "druid.router.http.numConnections"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "integer"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "25"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: true
+      asOfVersion: "0.0.0"
+
+  - property: &historicalCacheUseCache
+      propertyNames:
+        - name: "druid.historical.cache.useCache"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &historicalCachePopulateCache
+      propertyNames:
+        - name: "druid.historical.cache.populateCache"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &coordinatorStartDelay
+      propertyNames:
+        - name: "druid.coordinator.startDelay"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+        unit: *unitDuration
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "PT20S"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerQueueStartDelay
+      propertyNames:
+        - name: "druid.indexer.queue.startDelay"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+        unit: *unitDuration
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "PT20S"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerRunnerType
+      propertyNames:
+        - name: "druid.indexer.runner.type"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      allowedValues:
+        - "local"
+        - "remote"
+        - "httpRemote"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "remote"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &indexerStorageType
+      propertyNames:
+        - name: "druid.indexer.storage.type"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      allowedValues:
+        - "local"
+        - "metadata"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "metadata"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &coordinatorPeriod
+      propertyNames:
+        - name: "druid.coordinator.period"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+        unit: *unitDuration
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "PT20S"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &coordinatorAsOverlordEnabled
+      propertyNames:
+        - name: "druid.coordinator.asOverlord.enabled"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "bool"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "true"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
+        - name: "historical"
+          required: false
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &segmentCacheLocations
+      propertyNames:
+        - name: "druid.segmentCache.locations"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "[{\"path\":\"/stackable/var/druid/segment-cache\",\"maxSize\":\"300g\"}]"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: false
+        - name: "historical"
+          required: true
+        - name: "middleManager"
+          required: false
+        - name: "router"
+          required: false
+      asOfVersion: "0.0.0"
+
+  - property: &coordinatorAsOverlordOverlordService
+      propertyNames:
+        - name: "druid.coordinator.asOverlord.overlordService"
+          kind:
+            type: "file"
+            file: "runtime.properties"
+      datatype:
+        type: "string"
+      defaultValues:
+        - fromVersion: "0.0.0"
+          value: "druid/overlord"
+      roles:
+        - name: "broker"
+          required: false
+        - name: "coordinator"
+          required: true
         - name: "historical"
           required: false
         - name: "middleManager"

--- a/deploy/manifests/configmap.yaml
+++ b/deploy/manifests/configmap.yaml
@@ -4,11 +4,72 @@ apiVersion: v1
 data:
   properties.yaml: "version: 0.1.0\nspec:\n  units:\n    - unit: &unitDirectory\n        name:
     \"directory\"\n        regex: \"^/|(/[\\\\w-]+)+$\"\n        examples:\n          -
-    \"/tmp/xyz\"\n\n###################################################################################################\n#
-    runtime.properties\n###################################################################################################\n\nproperties:\n\n
-    \ - property: &metadataStorageType\n      propertyNames:\n        - name: \"druid.metadata.storage.type\"\n
+    \"/tmp/xyz\"\n    - unit: &unitPort\n        name: \"port\"\n        regex: \"^([0-9]{1,4}|[1-5][0-9]{4}|6[0-4][0-9]{3}|65[0-4][0-9]{2}|655[0-2][0-9]|6553[0-5])$\"\n
+    \   - unit: &unitPrometheusNamespace\n        name: \"prometheusNamespace\"\n        regex:
+    \"^[a-zA-Z_:][a-zA-Z0-9_:]*$\"\n    - unit: &unitDuration\n        name: \"duration\"\n
+    \       regex: \"^P(?!$)(\\\\d+Y)?(\\\\d+M)?(\\\\d+W)?(\\\\d+D)?(T(?=\\\\d)(\\\\d+H)?(\\\\d+M)?(\\\\d+S)?)?$\"\n
+    \       examples:\n          - \"PT300S\"\n\n###################################################################################################\n#
+    runtime.properties\n# For information on the properties, see: https://druid.apache.org/docs/latest/configuration/index.html\n###################################################################################################\n\nproperties:\n\n
+    \ - property: &plaintext\n      propertyNames:\n        - name: \"druid.plaintext\"\n
     \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
-    \     datatype:\n        type: \"string\"\n      roles:\n        - name: \"broker\"\n
+    \     datatype:\n        type: \"integer\"\n        min: \"1\"\n        max: \"65535\"\n
+    \       unit: *unitPort\n      roles:\n        - name: \"broker\"\n          required:
+    true\n        - name: \"coordinator\"\n          required: true\n        - name:
+    \"historical\"\n          required: true\n        - name: \"middleManager\"\n          required:
+    true\n        - name: \"router\"\n          required: true\n      asOfVersion: \"0.0.0\"\n\n
+    \ - property: &startupLoggingLogProperties\n      propertyNames:\n        - name:
+    \"druid.startup.logging.logProperties\"\n          kind:\n            type: \"file\"\n
+    \           file: \"runtime.properties\"\n      datatype:\n        type: \"bool\"\n
+    \     defaultValues:\n        - fromVersion: \"0.0.0\"\n          value: \"true\"\n
+    \     roles:\n        - name: \"broker\"\n          required: true\n        - name:
+    \"coordinator\"\n          required: true\n        - name: \"historical\"\n          required:
+    true\n        - name: \"middleManager\"\n          required: true\n        - name:
+    \"router\"\n          required: true\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &monitoringMonitors\n      propertyNames:\n        - name: \"druid.monitoring.monitors\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"string\"\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"[\\\"org.apache.druid.java.util.metrics.JvmMonitor\\\"]\"\n
+    \     roles:\n        - name: \"broker\"\n          required: true\n        - name:
+    \"coordinator\"\n          required: true\n        - name: \"historical\"\n          required:
+    true\n        - name: \"middleManager\"\n          required: true\n        - name:
+    \"router\"\n          required: true\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &emitter\n      propertyNames:\n        - name: \"druid.emitter\"\n          kind:\n
+    \           type: \"file\"\n            file: \"runtime.properties\"\n      datatype:\n
+    \       type: \"string\"\n      defaultValues:\n        - fromVersion: \"0.0.0\"\n
+    \         value: \"prometheus\"\n      allowedValues:\n        - \"noop\"\n        -
+    \"logging\"\n        - \"http\"\n        - \"parametrized\"\n        - \"composing\"\n
+    \       - \"prometheus\"\n      roles:\n        - name: \"broker\"\n          required:
+    true\n        - name: \"coordinator\"\n          required: true\n        - name:
+    \"historical\"\n          required: true\n        - name: \"middleManager\"\n          required:
+    true\n        - name: \"router\"\n          required: true\n      asOfVersion: \"0.0.0\"\n\n
+    \ - property: &emitterPrometheusStrategy\n      propertyNames:\n        - name:
+    \"druid.emitter.prometheus.strategy\"\n          kind:\n            type: \"file\"\n
+    \           file: \"runtime.properties\"\n      datatype:\n        type: \"string\"\n
+    \     defaultValues:\n        - fromVersion: \"0.0.0\"\n          value: \"exporter\"\n
+    \     allowedValues:\n        - \"exporter\"\n        - \"pushgateway\"\n      roles:\n
+    \       - name: \"broker\"\n          required: true\n        - name: \"coordinator\"\n
+    \         required: true\n        - name: \"historical\"\n          required: true\n
+    \       - name: \"middleManager\"\n          required: true\n        - name: \"router\"\n
+    \         required: true\n      asOfVersion: \"0.0.0\"\n\n  - property: &emitterPrometheusNamespace\n
+    \     propertyNames:\n        - name: \"druid.emitter.prometheus.namespace\"\n          kind:\n
+    \           type: \"file\"\n            file: \"runtime.properties\"\n      datatype:\n
+    \       type: \"string\"\n        unit: *unitPrometheusNamespace\n      defaultValues:\n
+    \       - fromVersion: \"0.0.0\"\n          value: \"druid\"\n      roles:\n        -
+    name: \"broker\"\n          required: true\n        - name: \"coordinator\"\n          required:
+    true\n        - name: \"historical\"\n          required: true\n        - name:
+    \"middleManager\"\n          required: true\n        - name: \"router\"\n          required:
+    true\n      asOfVersion: \"0.0.0\"\n\n  - property: &emitterPrometheusPort\n      propertyNames:\n
+    \       - name: \"druid.emitter.prometheus.port\"\n          kind:\n            type:
+    \"file\"\n            file: \"runtime.properties\"\n      datatype:\n        type:
+    \"integer\"\n        min: \"1\"\n        max: \"65535\"\n        unit: *unitPort\n
+    \     roles:\n        - name: \"broker\"\n          required: true\n        - name:
+    \"coordinator\"\n          required: true\n        - name: \"historical\"\n          required:
+    true\n        - name: \"middleManager\"\n          required: true\n        - name:
+    \"router\"\n          required: true\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &metadataStorageType\n      propertyNames:\n        - name: \"druid.metadata.storage.type\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"string\"\n      allowedValues:\n        - \"mysql\"\n
+    \       - \"postgresql\"\n        - \"derby\"\n      roles:\n        - name: \"broker\"\n
     \         required: true\n        - name: \"coordinator\"\n          required: true\n
     \       - name: \"historical\"\n          required: true\n        - name: \"middleManager\"\n
     \         required: true\n        - name: \"router\"\n          required: true\n
@@ -28,25 +89,163 @@ data:
     \     asOfVersion: \"0.0.0\"\n\n  - property: &metadataStoragePort\n      propertyNames:\n
     \       - name: \"druid.metadata.storage.connector.port\"\n          kind:\n            type:
     \"file\"\n            file: \"runtime.properties\"\n      datatype:\n        type:
-    \"integer\"\n        min: \"1024\"\n        max: \"65535\"\n      roles:\n        -
-    name: \"broker\"\n          required: true\n        - name: \"coordinator\"\n          required:
-    true\n        - name: \"historical\"\n          required: true\n        - name:
-    \"middleManager\"\n          required: true\n        - name: \"router\"\n          required:
-    true\n      asOfVersion: \"0.0.0\"\n\n  - property: &metadataStorageUser\n      propertyNames:\n
-    \       - name: \"druid.metadata.storage.connector.user\"\n          kind:\n            type:
+    \"integer\"\n        min: \"1024\"\n        max: \"65535\"\n        unit: *unitPort\n
+    \     roles:\n        - name: \"broker\"\n          required: true\n        - name:
+    \"coordinator\"\n          required: true\n        - name: \"historical\"\n          required:
+    true\n        - name: \"middleManager\"\n          required: true\n        - name:
+    \"router\"\n          required: true\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &metadataStorageUser\n      propertyNames:\n        - name: \"druid.metadata.storage.connector.user\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"string\"\n      roles:\n        - name: \"broker\"\n
+    \         required: false\n        - name: \"coordinator\"\n          required:
+    false\n        - name: \"historical\"\n          required: false\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    false\n      asOfVersion: \"0.0.0\"\n\n  - property: &metadataStoragePassword\n
+    \     propertyNames:\n        - name: \"druid.metadata.storage.connector.password\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"string\"\n      roles:\n        - name: \"broker\"\n
+    \         required: false\n        - name: \"coordinator\"\n          required:
+    false\n        - name: \"historical\"\n          required: false\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    false\n      asOfVersion: \"0.0.0\"\n\n  - property: &indexerLogsDirectory\n      propertyNames:\n
+    \       - name: \"druid.indexer.logs.directory\"\n          kind:\n            type:
     \"file\"\n            file: \"runtime.properties\"\n      datatype:\n        type:
-    \"string\"\n      roles:\n        - name: \"broker\"\n          required: false\n
-    \       - name: \"coordinator\"\n          required: false\n        - name: \"historical\"\n
+    \"string\"\n        unit: *unitDirectory\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"/stackable/var/druid/indexing-logs\"\n      roles:\n
+    \       - name: \"broker\"\n          required: true\n        - name: \"coordinator\"\n
+    \         required: true\n        - name: \"historical\"\n          required: true\n
+    \       - name: \"middleManager\"\n          required: true\n        - name: \"router\"\n
+    \         required: true\n      asOfVersion: \"0.0.0\"\n\n  - property: &processingTmpDir\n
+    \     propertyNames:\n        - name: \"druid.processing.tmpDir\"\n          kind:\n
+    \           type: \"file\"\n            file: \"runtime.properties\"\n      datatype:\n
+    \       type: \"string\"\n        unit: *unitDirectory\n      defaultValues:\n        -
+    fromVersion: \"0.0.0\"\n          value: \"/stackable/var/druid/processing\"\n      roles:\n
+    \       - name: \"broker\"\n          required: true\n        - name: \"coordinator\"\n
+    \         required: false\n        - name: \"historical\"\n          required: true\n
+    \       - name: \"middleManager\"\n          required: false\n        - name: \"router\"\n
+    \         required: false\n      asOfVersion: \"0.0.0\"\n\n  - property: &indexerTaskHadoopWorkingPath\n
+    \     propertyNames:\n        - name: \"druid.indexer.task.hadoopWorkingPath\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"string\"\n        unit: *unitDirectory\n      defaultValues:\n
+    \       - fromVersion: \"0.0.0\"\n          value: \"/stackable/var/druid/hadoop-tmp\"\n
+    \     roles:\n        - name: \"broker\"\n          required: false\n        - name:
+    \"coordinator\"\n          required: false\n        - name: \"historical\"\n          required:
+    false\n        - name: \"middleManager\"\n          required: true\n        - name:
+    \"router\"\n          required: false\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &indexerTaskBaseTaskDir\n      propertyNames:\n        - name: \"druid.indexer.task.baseTaskDir\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"string\"\n        unit: *unitDirectory\n      defaultValues:\n
+    \       - fromVersion: \"0.0.0\"\n          value: \"/stackable/var/druid/task\"\n
+    \     roles:\n        - name: \"broker\"\n          required: false\n        - name:
+    \"coordinator\"\n          required: false\n        - name: \"historical\"\n          required:
+    false\n        - name: \"middleManager\"\n          required: true\n        - name:
+    \"router\"\n          required: false\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &indexerRunnerJavaOpts\n      propertyNames:\n        - name: \"druid.indexer.runner.javaOpts\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"string\"\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"-server -Xms256m -Xmx256m -XX:MaxDirectMemorySize=300m
+    -Duser.timezone=UTC -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager\"\n
+    \     roles:\n        - name: \"broker\"\n          required: false\n        - name:
+    \"coordinator\"\n          required: false\n        - name: \"historical\"\n          required:
+    false\n        - name: \"middleManager\"\n          required: true\n        - name:
+    \"router\"\n          required: false\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &routerManagementProxyEnabled\n      propertyNames:\n        # Management proxy
+    to coordinator / overlord: required for unified web console.\n        - name: \"druid.router.managementProxy.enabled\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"bool\"\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"true\"\n      roles:\n        - name: \"broker\"\n
+    \         required: false\n        - name: \"coordinator\"\n          required:
+    false\n        - name: \"historical\"\n          required: false\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    true\n      asOfVersion: \"0.0.0\"\n\n  - property: &routerHttpNumConnections\n
+    \     propertyNames:\n        - name: \"druid.router.http.numConnections\"\n          kind:\n
+    \           type: \"file\"\n            file: \"runtime.properties\"\n      datatype:\n
+    \       type: \"integer\"\n      defaultValues:\n        - fromVersion: \"0.0.0\"\n
+    \         value: \"25\"\n      roles:\n        - name: \"broker\"\n          required:
+    false\n        - name: \"coordinator\"\n          required: false\n        - name:
+    \"historical\"\n          required: false\n        - name: \"middleManager\"\n          required:
+    false\n        - name: \"router\"\n          required: true\n      asOfVersion:
+    \"0.0.0\"\n\n  - property: &historicalCacheUseCache\n      propertyNames:\n        -
+    name: \"druid.historical.cache.useCache\"\n          kind:\n            type: \"file\"\n
+    \           file: \"runtime.properties\"\n      datatype:\n        type: \"bool\"\n
+    \     defaultValues:\n        - fromVersion: \"0.0.0\"\n          value: \"true\"\n
+    \     roles:\n        - name: \"broker\"\n          required: false\n        - name:
+    \"coordinator\"\n          required: false\n        - name: \"historical\"\n          required:
+    true\n        - name: \"middleManager\"\n          required: false\n        - name:
+    \"router\"\n          required: false\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &historicalCachePopulateCache\n      propertyNames:\n        - name: \"druid.historical.cache.populateCache\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"bool\"\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"true\"\n      roles:\n        - name: \"broker\"\n
+    \         required: false\n        - name: \"coordinator\"\n          required:
+    false\n        - name: \"historical\"\n          required: true\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    false\n      asOfVersion: \"0.0.0\"\n\n  - property: &coordinatorStartDelay\n      propertyNames:\n
+    \       - name: \"druid.coordinator.startDelay\"\n          kind:\n            type:
+    \"file\"\n            file: \"runtime.properties\"\n      datatype:\n        type:
+    \"string\"\n        unit: *unitDuration\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"PT20S\"\n      roles:\n        - name: \"broker\"\n
+    \         required: false\n        - name: \"coordinator\"\n          required:
+    true\n        - name: \"historical\"\n          required: false\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    false\n      asOfVersion: \"0.0.0\"\n\n  - property: &indexerQueueStartDelay\n      propertyNames:\n
+    \       - name: \"druid.indexer.queue.startDelay\"\n          kind:\n            type:
+    \"file\"\n            file: \"runtime.properties\"\n      datatype:\n        type:
+    \"string\"\n        unit: *unitDuration\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"PT20S\"\n      roles:\n        - name: \"broker\"\n
+    \         required: false\n        - name: \"coordinator\"\n          required:
+    true\n        - name: \"historical\"\n          required: false\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    false\n      asOfVersion: \"0.0.0\"\n\n  - property: &indexerRunnerType\n      propertyNames:\n
+    \       - name: \"druid.indexer.runner.type\"\n          kind:\n            type:
+    \"file\"\n            file: \"runtime.properties\"\n      datatype:\n        type:
+    \"string\"\n      allowedValues:\n        - \"local\"\n        - \"remote\"\n        -
+    \"httpRemote\"\n      defaultValues:\n        - fromVersion: \"0.0.0\"\n          value:
+    \"remote\"\n      roles:\n        - name: \"broker\"\n          required: false\n
+    \       - name: \"coordinator\"\n          required: true\n        - name: \"historical\"\n
     \         required: false\n        - name: \"middleManager\"\n          required:
     false\n        - name: \"router\"\n          required: false\n      asOfVersion:
-    \"0.0.0\"\n\n  - property: &metadataStoragePassword\n      propertyNames:\n        -
-    name: \"druid.metadata.storage.connector.password\"\n          kind:\n            type:
+    \"0.0.0\"\n\n  - property: &indexerStorageType\n      propertyNames:\n        -
+    name: \"druid.indexer.storage.type\"\n          kind:\n            type: \"file\"\n
+    \           file: \"runtime.properties\"\n      datatype:\n        type: \"string\"\n
+    \     allowedValues:\n        - \"local\"\n        - \"metadata\"\n      defaultValues:\n
+    \       - fromVersion: \"0.0.0\"\n          value: \"metadata\"\n      roles:\n
+    \       - name: \"broker\"\n          required: false\n        - name: \"coordinator\"\n
+    \         required: true\n        - name: \"historical\"\n          required: false\n
+    \       - name: \"middleManager\"\n          required: false\n        - name: \"router\"\n
+    \         required: false\n      asOfVersion: \"0.0.0\"\n\n  - property: &coordinatorPeriod\n
+    \     propertyNames:\n        - name: \"druid.coordinator.period\"\n          kind:\n
+    \           type: \"file\"\n            file: \"runtime.properties\"\n      datatype:\n
+    \       type: \"string\"\n        unit: *unitDuration\n      defaultValues:\n        -
+    fromVersion: \"0.0.0\"\n          value: \"PT20S\"\n      roles:\n        - name:
+    \"broker\"\n          required: false\n        - name: \"coordinator\"\n          required:
+    true\n        - name: \"historical\"\n          required: false\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    false\n      asOfVersion: \"0.0.0\"\n\n  - property: &coordinatorAsOverlordEnabled\n
+    \     propertyNames:\n        - name: \"druid.coordinator.asOverlord.enabled\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"bool\"\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"true\"\n      roles:\n        - name: \"broker\"\n
+    \         required: false\n        - name: \"coordinator\"\n          required:
+    true\n        - name: \"historical\"\n          required: false\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    false\n      asOfVersion: \"0.0.0\"\n\n  - property: &segmentCacheLocations\n      propertyNames:\n
+    \       - name: \"druid.segmentCache.locations\"\n          kind:\n            type:
     \"file\"\n            file: \"runtime.properties\"\n      datatype:\n        type:
-    \"string\"\n      roles:\n        - name: \"broker\"\n          required: false\n
-    \       - name: \"coordinator\"\n          required: false\n        - name: \"historical\"\n
-    \         required: false\n        - name: \"middleManager\"\n          required:
-    false\n        - name: \"router\"\n          required: false\n      asOfVersion:
-    \"0.0.0\"\n\n###################################################################################################\n#
+    \"string\"\n      defaultValues:\n        - fromVersion: \"0.0.0\"\n          value:
+    \"[{\\\"path\\\":\\\"/stackable/var/druid/segment-cache\\\",\\\"maxSize\\\":\\\"300g\\\"}]\"\n
+    \     roles:\n        - name: \"broker\"\n          required: false\n        - name:
+    \"coordinator\"\n          required: false\n        - name: \"historical\"\n          required:
+    true\n        - name: \"middleManager\"\n          required: false\n        - name:
+    \"router\"\n          required: false\n      asOfVersion: \"0.0.0\"\n\n  - property:
+    &coordinatorAsOverlordOverlordService\n      propertyNames:\n        - name: \"druid.coordinator.asOverlord.overlordService\"\n
+    \         kind:\n            type: \"file\"\n            file: \"runtime.properties\"\n
+    \     datatype:\n        type: \"string\"\n      defaultValues:\n        - fromVersion:
+    \"0.0.0\"\n          value: \"druid/overlord\"\n      roles:\n        - name: \"broker\"\n
+    \         required: false\n        - name: \"coordinator\"\n          required:
+    true\n        - name: \"historical\"\n          required: false\n        - name:
+    \"middleManager\"\n          required: false\n        - name: \"router\"\n          required:
+    false\n      asOfVersion: \"0.0.0\"\n\n###################################################################################################\n#
     jvm.config\n###################################################################################################\n\n###################################################################################################\n#
     log.properties\n###################################################################################################\n\n
     \ - property: &ioTrino\n      propertyNames:\n        - name: \"io.trino\"\n          kind:\n

--- a/examples/simple-druid-cluster.yaml
+++ b/examples/simple-druid-cluster.yaml
@@ -34,10 +34,6 @@ spec:
     connString: jdbc:derby://localhost:1527/var/druid/metadata.db;create=true
     host: localhost
     port: 1527
-  s3:
-    endpoint: s3-de-central.profitbricks.com
-    credentialsSecret:
-      s3-credentials
   deepStorage:
     storageType: hdfs
     storageDirectory: hdfs://simple-hdfs-namenode-default-0:8020/data

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/stackabletech/druid-operator"
 version = "0.5.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { path = "../../../operator-rs" }
 
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/crd/Cargo.toml
+++ b/rust/crd/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/stackabletech/druid-operator"
 version = "0.5.0-nightly"
 
 [dependencies]
-# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
-stackable-operator = { path = "../../../operator-rs" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
 
 semver = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -8,7 +8,8 @@ repository = "https://github.com/stackabletech/druid-operator"
 version = "0.5.0-nightly"
 
 [dependencies]
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { path = "../../../operator-rs" }
 stackable-druid-crd = { path = "../crd" }
 anyhow = "1.0"
 clap = "3.1"
@@ -26,5 +27,6 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
+stackable-operator = { path = "../../../operator-rs" }
 stackable-druid-crd = { path = "../crd" }

--- a/rust/operator-binary/Cargo.toml
+++ b/rust/operator-binary/Cargo.toml
@@ -8,8 +8,7 @@ repository = "https://github.com/stackabletech/druid-operator"
 version = "0.5.0-nightly"
 
 [dependencies]
-# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
-stackable-operator = { path = "../../../operator-rs" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
 stackable-druid-crd = { path = "../crd" }
 anyhow = "1.0"
 clap = "3.1"
@@ -27,6 +26,5 @@ tracing = "0.1"
 
 [build-dependencies]
 built = { version =  "0.5", features = ["chrono", "git2"] }
-# stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.13.0" }
-stackable-operator = { path = "../../../operator-rs" }
+stackable-operator = { git = "https://github.com/stackabletech/operator-rs.git", tag = "0.14.1" }
 stackable-druid-crd = { path = "../crd" }

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -90,22 +90,8 @@ pub fn get_runtime_properties(
         DruidRole::Broker => "
         druid.service=druid/broker
 
-        # HTTP server settings
-        druid.server.http.numThreads=6
-
-        # HTTP client settings
-        druid.broker.http.numConnections=5
-        druid.broker.http.maxQueuedBytes=5MiB
-
         # Processing threads and buffers
-        druid.processing.buffer.sizeBytes=50MiB
-        druid.processing.numMergeBuffers=2
-        druid.processing.numThreads=1
         druid.processing.tmpDir=/stackable/var/druid/processing
-
-        # Query cache disabled -- push down caching and merging instead
-        druid.broker.cache.useCache=false
-        druid.broker.cache.populateCache=false
         ",
         DruidRole::Coordinator => "
         druid.service=druid/coordinator
@@ -125,13 +111,6 @@ pub fn get_runtime_properties(
         DruidRole::Historical => "
         druid.service=druid/historical
 
-        # HTTP server threads
-        druid.server.http.numThreads=6
-
-        # Processing threads and buffers
-        druid.processing.buffer.sizeBytes=50MiB
-        druid.processing.numMergeBuffers=2
-        druid.processing.numThreads=1
         druid.processing.tmpDir=/stackable/var/druid/processing
 
         # Segment storage
@@ -140,26 +119,14 @@ pub fn get_runtime_properties(
         # Query cache
         druid.historical.cache.useCache=true
         druid.historical.cache.populateCache=true
-        druid.cache.type=caffeine
         druid.cache.sizeInBytes=50MiB
         ",
         DruidRole::MiddleManager => "
         druid.service=druid/middleManager
 
-        # Number of tasks per middleManager
-        druid.worker.capacity=2
-
         # Task launch parameters
         druid.indexer.runner.javaOpts=-server -Xms256m -Xmx256m -XX:MaxDirectMemorySize=300m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
         druid.indexer.task.baseTaskDir=/stackable/var/druid/task
-
-        # HTTP server threads
-        druid.server.http.numThreads=6
-
-        # Processing threads and buffers on Peons
-        druid.indexer.fork.property.druid.processing.numMergeBuffers=2
-        druid.indexer.fork.property.druid.processing.buffer.sizeBytes=25MiB
-        druid.indexer.fork.property.druid.processing.numThreads=1
 
         # Hadoop indexing
         druid.indexer.task.hadoopWorkingPath=/stackable/var/druid/hadoop-tmp

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -87,51 +87,22 @@ pub fn get_runtime_properties(
         DruidRole::Coordinator => "
         druid.service=druid/coordinator
 
-        druid.coordinator.startDelay=PT10S
-        druid.coordinator.period=PT5S
-
         # Run the overlord service in the coordinator process
-        druid.coordinator.asOverlord.enabled=true
+
         druid.coordinator.asOverlord.overlordService=druid/overlord
-
-        druid.indexer.queue.startDelay=PT5S
-
-        druid.indexer.runner.type=remote
-        druid.indexer.storage.type=metadata
         ",
         DruidRole::Historical => "
         druid.service=druid/historical
-
-        # Segment storage
-        druid.segmentCache.locations=[{\"path\":\"/stackable/var/druid/segment-cache\",\"maxSize\":\"300g\"}]
-
-        # Query cache
-        druid.historical.cache.useCache=true
-        druid.historical.cache.populateCache=true
-        druid.cache.sizeInBytes=50MiB
         ",
         DruidRole::MiddleManager => "
         druid.service=druid/middleManager
-
-        # Task launch parameters
-        druid.indexer.runner.javaOpts=-server -Xms256m -Xmx256m -XX:MaxDirectMemorySize=300m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
-        druid.indexer.task.baseTaskDir=/stackable/var/druid/task
         ",
         DruidRole::Router => "
         druid.service=druid/router
 
-        # HTTP proxy
-        druid.router.http.numConnections=25
-        druid.router.http.readTimeout=PT5M
-        druid.router.http.numMaxThreads=50
-        druid.server.http.numThreads=50
-
         # Service discovery
         druid.router.defaultBrokerServiceName=druid/broker
         druid.router.coordinatorServiceName=druid/coordinator
-
-        # Management proxy to coordinator / overlord: required for unified web console.
-        druid.router.managementProxy.enabled=true
         ",
     };
     let others =

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -63,14 +63,10 @@ pub fn get_runtime_properties(
 ) -> Result<String, PropertiesWriterError> {
     let common = "
     druid.startup.logging.logProperties=true
-    druid.zk.paths.base=/druid
     druid.indexer.logs.type=file
-    druid.indexer.logs.directory=/stackable/var/druid/indexing-logs
     druid.selectors.indexing.serviceName=druid/overlord
     druid.selectors.coordinator.serviceName=druid/coordinator
     druid.monitoring.monitors=[\"org.apache.druid.java.util.metrics.JvmMonitor\"]
-    druid.server.hiddenProperties=[\"druid.s3.accessKey\",\"druid.s3.secretKey\",\"druid.metadata.storage.connector.password\"]
-    druid.lookup.enableLookupSyncOnStartup=false
     # The prometheus port is configured later
     druid.emitter=prometheus
     druid.emitter.prometheus.strategy=exporter
@@ -87,9 +83,6 @@ pub fn get_runtime_properties(
     let role_specifics = match role {
         DruidRole::Broker => "
         druid.service=druid/broker
-
-        # Processing threads and buffers
-        druid.processing.tmpDir=/stackable/var/druid/processing
         ",
         DruidRole::Coordinator => "
         druid.service=druid/coordinator
@@ -109,8 +102,6 @@ pub fn get_runtime_properties(
         DruidRole::Historical => "
         druid.service=druid/historical
 
-        druid.processing.tmpDir=/stackable/var/druid/processing
-
         # Segment storage
         druid.segmentCache.locations=[{\"path\":\"/stackable/var/druid/segment-cache\",\"maxSize\":\"300g\"}]
 
@@ -125,9 +116,6 @@ pub fn get_runtime_properties(
         # Task launch parameters
         druid.indexer.runner.javaOpts=-server -Xms256m -Xmx256m -XX:MaxDirectMemorySize=300m -Duser.timezone=UTC -Dfile.encoding=UTF-8 -XX:+ExitOnOutOfMemoryError -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager
         druid.indexer.task.baseTaskDir=/stackable/var/druid/task
-
-        # Hadoop indexing
-        druid.indexer.task.hadoopWorkingPath=/stackable/var/druid/hadoop-tmp
         ",
         DruidRole::Router => "
         druid.service=druid/router

--- a/rust/operator-binary/src/config.rs
+++ b/rust/operator-binary/src/config.rs
@@ -69,9 +69,7 @@ pub fn get_runtime_properties(
     druid.selectors.indexing.serviceName=druid/overlord
     druid.selectors.coordinator.serviceName=druid/coordinator
     druid.monitoring.monitors=[\"org.apache.druid.java.util.metrics.JvmMonitor\"]
-    druid.indexing.doubleStorage=double
     druid.server.hiddenProperties=[\"druid.s3.accessKey\",\"druid.s3.secretKey\",\"druid.metadata.storage.connector.password\"]
-    druid.sql.enable=true
     druid.lookup.enableLookupSyncOnStartup=false
     # The prometheus port is configured later
     druid.emitter=prometheus

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -1,6 +1,6 @@
 //! Ensures that `Pod`s are configured and running for each [`DruidCluster`]
 use crate::{
-    config::{get_jvm_config, get_log4j_config, get_runtime_properties},
+    config::{get_jvm_config, get_log4j_config},
     discovery::{self, build_discovery_configmaps},
 };
 
@@ -288,7 +288,10 @@ fn build_rolegroup_config_map(
                     ZOOKEEPER_CONNECTION_STRING.to_string(),
                     Some(zk_connstr.clone()),
                 );
-                let runtime_properties = get_runtime_properties(&role, &transformed_config)
+                let runtime_properties =
+                    stackable_operator::product_config::writer::to_java_properties_string(
+                        transformed_config.iter(),
+                    )
                     .context(PropertiesWriteSnafu)?;
                 cm_conf_data.insert(RUNTIME_PROPS.to_string(), runtime_properties);
             }


### PR DESCRIPTION
## Description

- some properties I could not find in the configuration reference, I removed them without replacement
- some properties have sensible defaults, often computed from e.g. available cores. In those cases I just removed the property, making us use the calculated default
- some properties I moved to the product-config

fixes #28 

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
