### PR TITLE
[Merged by Bors] - Opa install timeout fix in tests

### DIFF
--- a/tests/templates/kuttl/authorizer/01-assert.yaml
+++ b/tests/templates/kuttl/authorizer/01-assert.yaml
@@ -3,5 +3,6 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 metadata:
   name: install-opa
+timeout: 300
 commands:
   - script: kubectl -n $NAMESPACE rollout status daemonset test-opa-server-default --timeout 300s


### PR DESCRIPTION
# Description

Added a larger timeout to the opa intsall step in the authorizer tests

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
