### PR TITLE
[Merged by Bors] - Fix s3 docs

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -141,14 +141,15 @@ Druid can use S3 as a backend for deep storage:
 spec:
   deepStorage:
     s3:
-      inline:
-        bucketName: my-bucket  # <1>
-        connection:
-          inline:
-            host: test-minio  # <2>
-            port: 9000  # <3>
-            credentials:  # <4>
-              ...
+      bucket:
+        inline:
+          bucketName: my-bucket  # <1>
+          connection:
+            inline:
+              host: test-minio  # <2>
+              port: 9000  # <3>
+              credentials:  # <4>
+                ...
 ----
 <1> Bucket name.
 <2> Bucket host.
@@ -162,7 +163,8 @@ It is also possible to configure the bucket connection details as a separate Kub
 spec:
   deepStorage:
     s3:
-      reference: my-bucket-resource # <1>
+      bucket:
+        reference: my-bucket-resource # <1>
 ----
 <1> Name of the bucket resource with connection details.
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -385,7 +385,7 @@ impl DeepStorageSpec {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, Eq, JsonSchema, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct HdfsDeepStorageSpec {
     pub config_map_name: String,


### PR DESCRIPTION
# Description

Came up via codecentric. Fixed missing "bucket" in the inline and reference examples in the docs

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
