### PR TITLE
[DO NOT MERGE] changed image pull location

### DIFF
--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -782,7 +782,7 @@ fn add_s3_volume_and_volume_mounts(
 }
 
 fn container_image(version: &str) -> String {
-    format!("docker.stackable.tech/stackable/druid:{}", version)
+    format!("docker.stackable.tech/sandbox/felix/druid:{}", version)
 }
 
 pub fn error_policy(_obj: Arc<DruidCluster>, _error: &Error, _ctx: Arc<Ctx>) -> Action {

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -2,8 +2,7 @@
 dimensions:
   - name: druid
     values:
-      - 0.23.0-stackable0.2.0
-      - 24.0.0-stackable0.2.0
+      - 24.0.0-stackable0
   - name: zookeeper
     values:
       - 3.7.0-stackable0.8.0


### PR DESCRIPTION
# Description

I'm just using this to test my new image

Can be closed and deleted after this has been merged: https://github.com/stackabletech/druid-opa-authorizer/pull/61

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
