### PR TITLE
[Merged by Bors] - Run init container non root and remove chmod/chown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Updated stackable image versions ([#339]).
 - Upgrade to `operator-rs` `0.26.1` ([#340])
 - Upgrade to `operator-rs` `0.27.1` ([#347])
+- Do not run init container as root anymore and avoid chmod and chown ([#353]).
 
 ### Removed
 
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#340]: https://github.com/stackabletech/druid-operator/pull/340
 [#342]: https://github.com/stackabletech/druid-operator/pull/342
 [#347]: https://github.com/stackabletech/druid-operator/pull/347
+[#353]: https://github.com/stackabletech/druid-operator/pull/353
 
 ## [0.8.0] - 2022-11-07
 

--- a/docs/modules/getting_started/examples/code/hdfs.yaml
+++ b/docs/modules/getting_started/examples/code/hdfs.yaml
@@ -4,7 +4,9 @@ kind: HdfsCluster
 metadata:
   name: simple-hdfs
 spec:
-  version: 3.3.4-stackable0.2.0
+  image:
+    productVersion: 3.3.4
+    stackableVersion: 0.2.0
   zookeeperConfigMapName: simple-hdfs-znode
   dfsReplication: 3
   nameNodes:

--- a/docs/modules/getting_started/examples/code/zookeeper.yaml
+++ b/docs/modules/getting_started/examples/code/zookeeper.yaml
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: simple-zk
 spec:
-  version: 3.5.8-stackable0.8.0
+  image:
+    productVersion: 3.8.0
+    stackableVersion: 0.8.0
   servers:
     roleGroups:
       default:

--- a/examples/psql-s3/psql-s3-druid-cluster.yaml
+++ b/examples/psql-s3/psql-s3-druid-cluster.yaml
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: simple-zk
 spec:
-  version: 3.8.0-stackable0.8.0
+  image:
+    productVersion: 3.8.0
+    stackableVersion: 0.8.0
   servers:
     roleGroups:
       default:

--- a/examples/psql/psql-hdfs-druid-cluster.yaml
+++ b/examples/psql/psql-hdfs-druid-cluster.yaml
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: simple-zk
 spec:
-  version: 3.8.0-stackable0.8.0
+  image:
+    productVersion: 3.8.0
+    stackableVersion: 0.8.0
   servers:
     roleGroups:
       default:
@@ -31,7 +33,9 @@ kind: HdfsCluster
 metadata:
   name: simple-hdfs
 spec:
-  version: 3.3.3-stackable0.2.0
+  image:
+    productVersion: 3.3.4
+    stackableVersion: 0.2.0
   zookeeperConfigMapName: psql-druid-znode
   dfsReplication: 1
   nameNodes:

--- a/examples/tls/tls-druid-cluster.yaml
+++ b/examples/tls/tls-druid-cluster.yaml
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: 3.8.0-stackable0.8.0
+  image:
+    productVersion: 3.8.0
+    stackableVersion: 0.8.0
   servers:
     roleGroups:
       default:
@@ -23,7 +25,9 @@ kind: HdfsCluster
 metadata:
   name: druid-hdfs
 spec:
-  version: 3.3.3-stackable0.1.0
+  image:
+    productVersion: 3.3.4
+    stackableVersion: 0.2.0
   zookeeperConfigMapName: druid-hdfs-znode
   dfsReplication: 1
   nameNodes:

--- a/rust/crd/src/tls.rs
+++ b/rust/crd/src/tls.rs
@@ -335,7 +335,6 @@ impl DruidTlsSettings {
                 TLS_ALIAS_NAME,
                 TLS_STORE_PASSWORD,
             ));
-            command.extend(chown_and_chmod(STACKABLE_TLS_DIR));
         }
         command
     }
@@ -399,15 +398,6 @@ pub fn add_key_pair_to_key_store_cmd(
         format!("cat {cert_directory}/ca.crt {cert_directory}/tls.crt > {key_store_directory}/chain.crt"),
         format!("echo Creating keystore [{key_store_directory}/keystore.p12]"),
         format!("openssl pkcs12 -export -in {key_store_directory}/chain.crt -inkey {cert_directory}/tls.key -out {key_store_directory}/keystore.p12 --passout pass:{store_password} -name {alias_name}"),
-    ]
-}
-
-/// Generates a shell script to chown and chmod the provided directory.
-pub fn chown_and_chmod(directory: &str) -> Vec<String> {
-    vec![
-        format!("echo chown and chmod {dir}", dir = directory),
-        format!("chown -R stackable:stackable {dir}", dir = directory),
-        format!("chmod -R a=,u=rwX {dir}", dir = directory),
     ]
 }
 

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -680,7 +680,7 @@ fn build_rolegroup_statefulset(
         PodSecurityContextBuilder::new()
             .run_as_user(1000)
             .run_as_group(1000)
-            .fs_group(1000) // Needed for secret-operator
+            .fs_group(1000)
             .build(),
     );
 

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -21,8 +21,7 @@ use stackable_druid_crd::{
 use stackable_operator::{
     builder::{
         ConfigMapBuilder, ContainerBuilder, ObjectMetaBuilder, PodBuilder,
-        PodSecurityContextBuilder, SecretOperatorVolumeSourceBuilder, SecurityContextBuilder,
-        VolumeBuilder,
+        PodSecurityContextBuilder, SecretOperatorVolumeSourceBuilder, VolumeBuilder,
     },
     cluster_resources::ClusterResources,
     commons::{
@@ -638,7 +637,6 @@ fn build_rolegroup_statefulset(
         .command(vec!["/bin/bash".to_string(), "-c".to_string()])
         .args(vec![prepare_container_command.join(" && ")])
         .image_pull_policy("IfNotPresent")
-        .security_context(SecurityContextBuilder::run_as_root())
         .build();
 
     // rest of env
@@ -678,7 +676,13 @@ fn build_rolegroup_statefulset(
             &rolegroup_ref.role_group,
         ))
     });
-    pb.security_context(PodSecurityContextBuilder::new().fs_group(1000).build()); // Needed for secret-operator
+    pb.security_context(
+        PodSecurityContextBuilder::new()
+            .run_as_user(1000)
+            .run_as_group(1000)
+            .fs_group(1000) // Needed for secret-operator
+            .build(),
+    );
 
     Ok(StatefulSet {
         metadata: ObjectMetaBuilder::new()

--- a/tests/templates/kuttl/authorizer/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/authorizer/00-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/authorizer/02-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/authorizer/02-install-hdfs.yaml.j2
@@ -10,7 +10,9 @@ kind: HdfsCluster
 metadata:
   name: druid-hdfs
 spec:
-  version: {{ test_scenario['values']['hadoop'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[1] }}"
   zookeeperConfigMapName: hdfs-znode
   dfsReplication: 1
   nameNodes:

--- a/tests/templates/kuttl/hdfs-deep-storage/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/hdfs-deep-storage/00-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/hdfs-deep-storage/01-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/hdfs-deep-storage/01-install-hdfs.yaml.j2
@@ -10,7 +10,9 @@ kind: HdfsCluster
 metadata:
   name: druid-hdfs
 spec:
-  version: {{ test_scenario['values']['hadoop'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[1] }}"
   zookeeperConfigMapName: druid-hdfs-znode
   dfsReplication: 1
   nameNodes:

--- a/tests/templates/kuttl/ingestion-no-s3-ext/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/ingestion-no-s3-ext/00-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/ingestion-no-s3-ext/01-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/ingestion-no-s3-ext/01-install-hdfs.yaml.j2
@@ -10,7 +10,9 @@ kind: HdfsCluster
 metadata:
   name: druid-hdfs
 spec:
-  version: {{ test_scenario['values']['hadoop'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[1] }}"
   zookeeperConfigMapName: hdfs-znode
   dfsReplication: 1
   nameNodes:

--- a/tests/templates/kuttl/ingestion-s3-ext/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/ingestion-s3-ext/00-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/ingestion-s3-ext/01-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/ingestion-s3-ext/01-install-hdfs.yaml.j2
@@ -10,7 +10,9 @@ kind: HdfsCluster
 metadata:
   name: druid-hdfs
 spec:
-  version: {{ test_scenario['values']['hadoop'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[1] }}"
   zookeeperConfigMapName: hdfs-znode
   dfsReplication: 1
   nameNodes:

--- a/tests/templates/kuttl/orphaned-resources/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/00-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/orphaned-resources/01-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/01-install-hdfs.yaml.j2
@@ -10,7 +10,9 @@ kind: HdfsCluster
 metadata:
   name: druid-hdfs
 spec:
-  version: {{ test_scenario['values']['hadoop'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[1] }}"
   zookeeperConfigMapName: hdfs-znode
   dfsReplication: 1
   nameNodes:

--- a/tests/templates/kuttl/resources/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/resources/00-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/s3-deep-storage/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/s3-deep-storage/00-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/smoke/01-install-zk.yaml.j2
+++ b/tests/templates/kuttl/smoke/01-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:

--- a/tests/templates/kuttl/smoke/02-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/smoke/02-install-hdfs.yaml.j2
@@ -10,7 +10,9 @@ kind: HdfsCluster
 metadata:
   name: druid-hdfs
 spec:
-  version: {{ test_scenario['values']['hadoop'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[1] }}"
   zookeeperConfigMapName: hdfs-znode
   dfsReplication: 1
   nameNodes:

--- a/tests/templates/kuttl/tls/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/tls/00-install-zk.yaml.j2
@@ -4,7 +4,9 @@ kind: ZookeeperCluster
 metadata:
   name: druid-zk
 spec:
-  version: {{ test_scenario['values']['zookeeper-latest'] }}
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
   servers:
     roleGroups:
       default:


### PR DESCRIPTION
# Description

- run init container as non root
- added run as user and group (1000)
- removed chown and chmods in init scripts
- Adapted tests to new nightly product image selection of zk and hdfs operator 

test: https://ci.stackable.tech/view/02%20Operator%20Tests%20(custom)/job/druid-operator-it-custom/45/console

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
