### PR TITLE
LDAP authentication

### DIFF
--- a/docs/modules/ROOT/pages/usage.adoc
+++ b/docs/modules/ROOT/pages/usage.adoc
@@ -307,7 +307,7 @@ spec:
 
 ==== LDAP
 
-Currently not supported.
+TODO: add more info here.
 
 === Authorization with Open Policy Agent (OPA)
 

--- a/tests/templates/kuttl/ldap-authentication/00-assert.yaml
+++ b/tests/templates/kuttl/ldap-authentication/00-assert.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-zk-server-default
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hdfs-znode

--- a/tests/templates/kuttl/ldap-authentication/00-install-zk.yaml.j2
+++ b/tests/templates/kuttl/ldap-authentication/00-install-zk.yaml.j2
@@ -1,0 +1,29 @@
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperCluster
+metadata:
+  name: druid-zk
+spec:
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
+  servers:
+    roleGroups:
+      default:
+        replicas: 1
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperZnode
+metadata:
+  name: druid-znode
+spec:
+  clusterRef:
+    name: druid-zk
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperZnode
+metadata:
+  name: hdfs-znode
+spec:
+  clusterRef:
+    name: druid-zk

--- a/tests/templates/kuttl/ldap-authentication/02-assert.yaml
+++ b/tests/templates/kuttl/ldap-authentication/02-assert.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-hdfs-namenode-default
+status:
+  readyReplicas: 2
+  replicas: 2
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-hdfs-journalnode-default
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-hdfs-datanode-default
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/ldap-authentication/02-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/ldap-authentication/02-install-hdfs.yaml.j2
@@ -1,0 +1,29 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: druid-hdfs
+timeout: 600
+---
+apiVersion: hdfs.stackable.tech/v1alpha1
+kind: HdfsCluster
+metadata:
+ name: druid-hdfs
+spec:
+ image:
+   productVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[0] }}"
+   stackableVersion: "{{ test_scenario['values']['hadoop'].split('-stackable')[1] }}"
+ zookeeperConfigMapName: hdfs-znode
+ dfsReplication: 1
+ nameNodes:
+   roleGroups:
+     default:
+       replicas: 2
+ dataNodes:
+   roleGroups:
+     default:
+       replicas: 1
+ journalNodes:
+   roleGroups:
+     default:
+       replicas: 1

--- a/tests/templates/kuttl/ldap-authentication/03-assert-openldap.yaml
+++ b/tests/templates/kuttl/ldap-authentication/03-assert-openldap.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openldap
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/ldap-authentication/03-install-openldap.yaml
+++ b/tests/templates/kuttl/ldap-authentication/03-install-openldap.yaml
@@ -1,0 +1,73 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openldap
+  labels:
+    app.kubernetes.io/name: openldap
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: openldap
+  serviceName: openldap
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: openldap
+    spec:
+      containers:
+        - name: openldap
+          image: docker.io/bitnami/openldap:2.5
+          env:
+            - name: LDAP_ADMIN_USERNAME
+              value: admin
+            - name: LDAP_ADMIN_PASSWORD
+              value: admin
+            - name: LDAP_ENABLE_TLS
+              value: "yes"
+            - name: LDAP_TLS_CERT_FILE
+              value: /tls/tls.crt
+            - name: LDAP_TLS_KEY_FILE
+              value: /tls/tls.key
+            - name: LDAP_TLS_CA_FILE
+              value: /tls/ca.crt
+          ports:
+            - name: ldap
+              containerPort: 1389
+            - name: tls-ldap
+              containerPort: 1636
+          volumeMounts:
+            - name: tls
+              mountPath: /tls
+          startupProbe:
+            tcpSocket:
+              port: 1389
+          readinessProbe:
+            tcpSocket:
+              port: 1389
+      volumes:
+        - name: tls
+          csi:
+            driver: secrets.stackable.tech
+            volumeAttributes:
+              secrets.stackable.tech/class: openldap-tls
+              secrets.stackable.tech/scope: pod
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: openldap
+  labels:
+    app.kubernetes.io/name: openldap
+spec:
+  type: ClusterIP
+  ports:
+    - name: ldap
+      port: 1389
+      targetPort: ldap
+    - name: tls-ldap
+      port: 1636
+      targetPort: tls-ldap
+  selector:
+    app.kubernetes.io/name: openldap

--- a/tests/templates/kuttl/ldap-authentication/03-openldap-secret-class.yaml
+++ b/tests/templates/kuttl/ldap-authentication/03-openldap-secret-class.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: openldap
+commands:
+  # SecretClass requires an explicit namespace to work
+  - script: |
+      kubectl apply -n $NAMESPACE -f - <<EOF
+      ---
+      apiVersion: secrets.stackable.tech/v1alpha1
+      kind: SecretClass
+      metadata:
+        name: openldap-tls
+      spec:
+        backend:
+          autoTls:
+            ca:
+              autoGenerate: true
+              secret:
+                name: openldap-tls-ca
+                namespace: $NAMESPACE
+      EOF

--- a/tests/templates/kuttl/ldap-authentication/04-assert-ldap-user.yaml
+++ b/tests/templates/kuttl/ldap-authentication/04-assert-ldap-user.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: kubectl exec -n $NAMESPACE openldap-0 -- ldapsearch -H ldap://localhost:1389 -D uid=admin,dc=example,dc=org -w admin -b ou=users,dc=example,dc=org > /dev/null
+  - script: kubectl exec -n $NAMESPACE openldap-0 -- bash -c LDAPTLS_CACERT=/tls/ca.crt ldapsearch -Z -H ldaps://localhost:1636 -D uid=admin,dc=example,dc=org -w admin -b ou=users,dc=example,dc=org > /dev/null

--- a/tests/templates/kuttl/ldap-authentication/04-ldap-user.yaml
+++ b/tests/templates/kuttl/ldap-authentication/04-ldap-user.yaml
@@ -1,0 +1,8 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: create-ldap-user
+commands:
+  - script: kubectl cp -n $NAMESPACE ./create_ldap_user.sh openldap-0:/tmp
+  - script: kubectl exec -n $NAMESPACE openldap-0 -- sh /tmp/create_ldap_user.sh

--- a/tests/templates/kuttl/ldap-authentication/05-assert.yaml
+++ b/tests/templates/kuttl/ldap-authentication/05-assert.yaml
@@ -1,0 +1,44 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: derby-druid-broker-default
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: derby-druid-coordinator-default
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: derby-druid-historical-default
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: derby-druid-middlemanager-default
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: derby-druid-router-default
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/ldap-authentication/05-install-druid.yaml.j2
+++ b/tests/templates/kuttl/ldap-authentication/05-install-druid.yaml.j2
@@ -1,0 +1,93 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-druid
+timeout: 600
+---
+apiVersion: authentication.stackable.tech/v1alpha1
+kind: AuthenticationClass
+metadata:
+  name: druid-ldap-auth-class
+spec:
+  provider:
+    ldap:
+      hostname: openldap
+      searchBase: ou=users,dc=example,dc=org
+      searchFilter: (uid=%s)
+{% if test_scenario['values']['ldap-use-tls'] == 'false' %}
+      port: 1389
+{% else %}
+      port: 1636
+      tls:
+        verification:
+          server:
+            caCert:
+              secretClass: openldap-tls
+{% endif %}
+      bindCredentials:
+        secretClass: druid-ldap-secret
+---
+apiVersion: secrets.stackable.tech/v1alpha1
+kind: SecretClass
+metadata:
+  name: druid-ldap-secret
+spec:
+  backend:
+    k8sSearch:
+      searchNamespace:
+        pod: {}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: druid-ldap-secret
+  labels:
+    secrets.stackable.tech/class: druid-ldap-secret
+stringData:
+  username: uid=admin,dc=example,dc=org
+  password: admin
+---
+apiVersion: druid.stackable.tech/v1alpha1
+kind: DruidCluster
+metadata:
+  name: derby-druid
+spec:
+  image:
+    productVersion: "{{ test_scenario['values']['druid'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['druid'].split('-stackable')[1] }}"
+  clusterConfig:
+    authentication:
+      - authenticationClass: druid-ldap-auth-class
+    deepStorage:
+      hdfs:
+        configMapName: druid-hdfs
+        directory: /druid
+    metadataStorageDatabase:
+      dbType: derby
+      connString: jdbc:derby://localhost:1527/var/druid/metadata.db;create=true
+      host: localhost
+      port: 1527
+    tls:
+      serverAndInternalSecretClass: null
+    zookeeperConfigMapName: druid-znode
+  brokers:
+    roleGroups:
+      default:
+        replicas: 1
+  coordinators:
+    roleGroups:
+      default:
+        replicas: 1
+  historicals:
+    roleGroups:
+      default:
+        replicas: 1
+  middleManagers:
+    roleGroups:
+      default:
+        replicas: 1
+  routers:
+    roleGroups:
+      default:
+        replicas: 1

--- a/tests/templates/kuttl/ldap-authentication/06-assert.yaml
+++ b/tests/templates/kuttl/ldap-authentication/06-assert.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: checks
+status:
+  readyReplicas: 1
+  replicas: 1

--- a/tests/templates/kuttl/ldap-authentication/06-checks-container.yaml
+++ b/tests/templates/kuttl/ldap-authentication/06-checks-container.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: checks
+  labels:
+    app: checks
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: checks
+  template:
+    metadata:
+      labels:
+        app: checks
+    spec:
+      containers:
+        - name: checks
+          image: docker.stackable.tech/stackable/testing-tools:0.1.0-stackable0.1.0
+          command: ["sleep", "infinity"]

--- a/tests/templates/kuttl/ldap-authentication/07-assert.yaml
+++ b/tests/templates/kuttl/ldap-authentication/07-assert.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+commands:
+  - script: kubectl exec -n $NAMESPACE checks-0 -- python /tmp/authcheck.py
+timeout: 600

--- a/tests/templates/kuttl/ldap-authentication/07-authcheck.yaml
+++ b/tests/templates/kuttl/ldap-authentication/07-authcheck.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+timeout: 600
+commands:
+  - script: kubectl cp -n $NAMESPACE ./authcheck.py  checks-0:/tmp

--- a/tests/templates/kuttl/ldap-authentication/README.md
+++ b/tests/templates/kuttl/ldap-authentication/README.md
@@ -1,0 +1,5 @@
+# LDAP Authenticator Test
+
+This test sets an LDAP user called 'alice'.
+
+See `authcheck.py` for examples of authorized access.

--- a/tests/templates/kuttl/ldap-authentication/authcheck.py
+++ b/tests/templates/kuttl/ldap-authentication/authcheck.py
@@ -1,0 +1,57 @@
+import requests
+import sys
+import logging
+
+
+def main():
+    result = 0
+
+    proto = "http"
+    druid_cluster_name = "derby-druid"
+
+    druid_ports = {
+        "coordinator": 8081,
+        # "broker": 8082,
+        # "middlemanager": 8091,
+        # "historical": 8083,
+        # "router": 8888
+    }
+    log_level = 'INFO'
+    logging.basicConfig(level=log_level, format='%(asctime)s %(levelname)s: %(message)s', stream=sys.stdout)
+
+    for role, port in druid_ports.items():
+        url = f"{proto}://{druid_cluster_name}-{role}-default:{port}/status"
+        # make an authorized request -> return 401 expected
+        logging.info(f"making unauthorized request to {role}.")
+        res = requests.get(url)
+        if res.status_code != 401:
+            logging.error(f"expected 401 but got {res.status_code}")
+            result = 1
+            break
+        else:
+            logging.info("success")
+        # make an authorized request -> return 200 expected
+        logging.info(f"making request as LDAP user [alice] to {role}")
+        res = requests.get(url, auth=("alice", "alice"))
+        if res.status_code != 200:
+            logging.error(f"expected 200 but got {res.status_code}")
+            result = 1
+            break
+        else:
+            logging.info("success")
+        # make an unauthorized request -> return 403 expected
+        # eve is not an ldap user
+        logging.info(f"making request as unknown user [eve] to {role}")
+        res = requests.get(url, auth=("eve", "eve"))
+        if res.status_code != 401:
+            logging.error(f"expected 401 but got {res.status_code}")
+            result = 1
+            break
+        else:
+            logging.info("success")
+
+    return result
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/templates/kuttl/ldap-authentication/create_ldap_user.sh
+++ b/tests/templates/kuttl/ldap-authentication/create_ldap_user.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+cat << 'EOF' | ldapadd -H ldap://localhost:1389 -D cn=admin,dc=example,dc=org -w admin
+dn: uid=alice,ou=users,dc=example,dc=org
+uid: alice
+cn: alice
+sn: alice
+objectClass: top
+objectClass: posixAccount
+objectClass: inetOrgPerson
+homeDirectory: /home/alice
+uidNumber: 3
+gidNumber: 3
+userPassword: alice
+EOF

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -29,6 +29,10 @@ dimensions:
       - "no-tls"
       - "internal-tls"
       - "internal-tls-and-tls-client-auth"
+  - name: ldap-use-tls
+    values:
+      #- "true" # commented out, as it is not yet functional
+      - "false"
 tests:
   - name: smoke
     dimensions:
@@ -75,3 +79,10 @@ tests:
       - druid-latest
       - zookeeper-latest
       - tls-mode
+  - name: ldap-authentication
+    dimensions:
+      - druid
+      - zookeeper-latest
+      - opa
+      - hadoop
+      - ldap-use-tls


### PR DESCRIPTION
# Description

Fixes https://github.com/stackabletech/druid-operator/issues/144

A new iteration on the changes prototyped in https://github.com/stackabletech/druid-operator/pull/341

This iteration will include:

* A closer resemblance to the ticket requirements - using a list of authenticators
* Non-usage of LDAP for inter-node authentication (basic authentication instead)
* Erroring out if both TLS auth and LDAP auth are configured

Stretch goals:

* Interconnection with an OPA authorization config, if provided
* Adding ldaps:// support

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Review Checklist

- [ ] Code contains useful comments
- [ ] CRD change approved (or not applicable)
- [ ] (Integration-)Test cases added (or not applicable)
- [ ] Documentation added (or not applicable)
- [ ] Changelog updated (or not applicable)
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
- [ ] Helm chart can be installed and deployed operator works (or not applicable)

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
