### PR TITLE
[Merged by Bors] - Added functionality to mount extra volumes with files needed for ingestion tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Add support for TLS LDAP authentication. ([#408])
 - Deploy default and support custom affinities ([#406]).
 - Log aggregation added ([#407]).
-- Added the ability to mount extra volumes for files that may be needed for ingestion tasks to work ([#xxx])
+- Added the ability to mount extra volumes for files that may be needed for ingestion tasks to work ([#415])
 
 ### Changed
 
@@ -29,7 +29,7 @@ All notable changes to this project will be documented in this file.
 [#406]: https://github.com/stackabletech/druid-operator/pull/406
 [#407]: https://github.com/stackabletech/druid-operator/pull/407
 [#408]: https://github.com/stackabletech/druid-operator/pull/408
-[#xxx]: https://github.com/stackabletech/druid-operator/pull/xxx
+[#415]: https://github.com/stackabletech/druid-operator/pull/415
 
 ## [23.1.0] - 2023-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Add support for TLS LDAP authentication. ([#408])
 - Deploy default and support custom affinities ([#406]).
 - Log aggregation added ([#407]).
+- Added the ability to mount extra volumes for files that may be needed for ingestion tasks to work ([#xxx])
 
 ### Changed
 
@@ -28,6 +29,7 @@ All notable changes to this project will be documented in this file.
 [#406]: https://github.com/stackabletech/druid-operator/pull/406
 [#407]: https://github.com/stackabletech/druid-operator/pull/407
 [#408]: https://github.com/stackabletech/druid-operator/pull/408
+[#xxx]: https://github.com/stackabletech/druid-operator/pull/xxx
 
 ## [23.1.0] - 2023-01-23
 

--- a/deploy/helm/druid-operator/crds/crds.yaml
+++ b/deploy/helm/druid-operator/crds/crds.yaml
@@ -1474,6 +1474,1082 @@ spec:
                             - bucket
                           type: object
                       type: object
+                    extraVolumes:
+                      description: Extra volumes to mount into every container, this can be useful to for example make client certificates, keytabs or similar things available to processors These volumes will be mounted into all pods
+                      items:
+                        description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                        properties:
+                          awsElasticBlockStore:
+                            description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: boolean
+                              volumeID:
+                                description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          azureDisk:
+                            description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                            properties:
+                              cachingMode:
+                                description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                                type: string
+                              diskName:
+                                description: diskName is the Name of the data disk in the blob storage
+                                type: string
+                              diskURI:
+                                description: diskURI is the URI of data disk in the blob storage
+                                type: string
+                              fsType:
+                                description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              kind:
+                                description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                            required:
+                              - diskName
+                              - diskURI
+                            type: object
+                          azureFile:
+                            description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                            properties:
+                              readOnly:
+                                description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretName:
+                                description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                                type: string
+                              shareName:
+                                description: shareName is the azure share Name
+                                type: string
+                            required:
+                              - secretName
+                              - shareName
+                            type: object
+                          cephfs:
+                            description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                            properties:
+                              monitors:
+                                description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              path:
+                                description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                                type: string
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: boolean
+                              secretFile:
+                                description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                              secretRef:
+                                description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                                type: string
+                            required:
+                              - monitors
+                            type: object
+                          cinder:
+                            description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                              readOnly:
+                                description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeID:
+                                description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          configMap:
+                            description: configMap represents a configMap that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                              optional:
+                                description: optional specify whether the ConfigMap or its keys must be defined
+                                type: boolean
+                            type: object
+                          csi:
+                            description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                            properties:
+                              driver:
+                                description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                                type: string
+                              fsType:
+                                description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                                type: string
+                              nodePublishSecretRef:
+                                description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              readOnly:
+                                description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
+                                type: boolean
+                              volumeAttributes:
+                                additionalProperties:
+                                  type: string
+                                description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                                type: object
+                            required:
+                              - driver
+                            type: object
+                          downwardAPI:
+                            description: downwardAPI represents downward API about the pod that should populate this volume
+                            properties:
+                              defaultMode:
+                                description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: Items is a list of downward API volume file
+                                items:
+                                  description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                  properties:
+                                    fieldRef:
+                                      description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                      properties:
+                                        apiVersion:
+                                          description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                          type: string
+                                        fieldPath:
+                                          description: Path of the field to select in the specified API version.
+                                          type: string
+                                      required:
+                                        - fieldPath
+                                      type: object
+                                    mode:
+                                      description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                      type: string
+                                    resourceFieldRef:
+                                      description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                      properties:
+                                        containerName:
+                                          description: 'Container name: required for volumes, optional for env vars'
+                                          type: string
+                                        divisor:
+                                          description: Specifies the output format of the exposed resources, defaults to "1"
+                                          type: string
+                                        resource:
+                                          description: 'Required: resource to select'
+                                          type: string
+                                      required:
+                                        - resource
+                                      type: object
+                                  required:
+                                    - path
+                                  type: object
+                                type: array
+                            type: object
+                          emptyDir:
+                            description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            properties:
+                              medium:
+                                description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                                type: string
+                              sizeLimit:
+                                description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                                type: string
+                            type: object
+                          ephemeral:
+                            description: |-
+                              ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                              Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                                 tracking are needed,
+                              c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                                 a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                                 information on the connection between this volume type
+                                 and PersistentVolumeClaim).
+
+                              Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                              Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                              A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                            properties:
+                              volumeClaimTemplate:
+                                description: |-
+                                  Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                                  An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                                  This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                                  Required, must not be nil.
+                                properties:
+                                  metadata:
+                                    description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                    properties:
+                                      annotations:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                        type: object
+                                      creationTimestamp:
+                                        description: |-
+                                          CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+                                          Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                        format: date-time
+                                        type: string
+                                      deletionGracePeriodSeconds:
+                                        description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                                        format: int64
+                                        type: integer
+                                      deletionTimestamp:
+                                        description: |-
+                                          DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+                                          Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                        format: date-time
+                                        type: string
+                                      finalizers:
+                                        description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                                        items:
+                                          type: string
+                                        type: array
+                                      generateName:
+                                        description: |-
+                                          GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                                          If this field is specified and the generated name exists, the server will return a 409.
+
+                                          Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                                        type: string
+                                      generation:
+                                        description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                                        format: int64
+                                        type: integer
+                                      labels:
+                                        additionalProperties:
+                                          type: string
+                                        description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                        type: object
+                                      managedFields:
+                                        description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                                        items:
+                                          description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+                                          properties:
+                                            apiVersion:
+                                              description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                                              type: string
+                                            fieldsType:
+                                              description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                                              type: string
+                                            fieldsV1:
+                                              description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                                              type: object
+                                            manager:
+                                              description: Manager is an identifier of the workflow managing these fields.
+                                              type: string
+                                            operation:
+                                              description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                                              type: string
+                                            subresource:
+                                              description: Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+                                              type: string
+                                            time:
+                                              description: Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.
+                                              format: date-time
+                                              type: string
+                                          type: object
+                                        type: array
+                                      name:
+                                        description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                        type: string
+                                      namespace:
+                                        description: |-
+                                          Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                                          Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                        type: string
+                                      ownerReferences:
+                                        description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                                        items:
+                                          description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                                          properties:
+                                            apiVersion:
+                                              description: API version of the referent.
+                                              type: string
+                                            blockOwnerDeletion:
+                                              description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                                              type: boolean
+                                            controller:
+                                              description: If true, this reference points to the managing controller.
+                                              type: boolean
+                                            kind:
+                                              description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                              type: string
+                                            name:
+                                              description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                              type: string
+                                            uid:
+                                              description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                              type: string
+                                          required:
+                                            - apiVersion
+                                            - kind
+                                            - name
+                                            - uid
+                                          type: object
+                                        type: array
+                                      resourceVersion:
+                                        description: |-
+                                          An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                                          Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                        type: string
+                                      selfLink:
+                                        description: 'Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.'
+                                        type: string
+                                      uid:
+                                        description: |-
+                                          UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                                          Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                        type: string
+                                    type: object
+                                  spec:
+                                    description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                    properties:
+                                      accessModes:
+                                        description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                        items:
+                                          type: string
+                                        type: array
+                                      dataSource:
+                                        description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      dataSourceRef:
+                                        description: |-
+                                          dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef
+                                            allows any non-core object, as well as PersistentVolumeClaim objects.
+                                          * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                            preserves all values, and generates an error if a disallowed value is
+                                            specified.
+                                          * While dataSource only allows local objects, dataSourceRef allows objects
+                                            in any namespaces.
+                                          (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        properties:
+                                          apiGroup:
+                                            description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                            type: string
+                                          kind:
+                                            description: Kind is the type of resource being referenced
+                                            type: string
+                                          name:
+                                            description: Name is the name of resource being referenced
+                                            type: string
+                                          namespace:
+                                            description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                            type: string
+                                        required:
+                                          - kind
+                                          - name
+                                        type: object
+                                      resources:
+                                        description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                        properties:
+                                          claims:
+                                            description: |-
+                                              Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.
+
+                                              This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+
+                                              This field is immutable.
+                                            items:
+                                              description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                              properties:
+                                                name:
+                                                  description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                                  type: string
+                                              required:
+                                                - name
+                                              type: object
+                                            type: array
+                                          limits:
+                                            additionalProperties:
+                                              description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                              type: string
+                                            description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                          requests:
+                                            additionalProperties:
+                                              description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                              type: string
+                                            description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                            type: object
+                                        type: object
+                                      selector:
+                                        description: selector is a label query over volumes to consider for binding.
+                                        properties:
+                                          matchExpressions:
+                                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                            items:
+                                              description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                              properties:
+                                                key:
+                                                  description: key is the label key that the selector applies to.
+                                                  type: string
+                                                operator:
+                                                  description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                  type: string
+                                                values:
+                                                  description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                  items:
+                                                    type: string
+                                                  type: array
+                                              required:
+                                                - key
+                                                - operator
+                                              type: object
+                                            type: array
+                                          matchLabels:
+                                            additionalProperties:
+                                              type: string
+                                            description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                            type: object
+                                        type: object
+                                      storageClassName:
+                                        description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                        type: string
+                                      volumeMode:
+                                        description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                        type: string
+                                      volumeName:
+                                        description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                        type: string
+                                    type: object
+                                required:
+                                  - spec
+                                type: object
+                            type: object
+                          fc:
+                            description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              lun:
+                                description: 'lun is Optional: FC target lun number'
+                                format: int32
+                                type: integer
+                              readOnly:
+                                description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                type: boolean
+                              targetWWNs:
+                                description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                                items:
+                                  type: string
+                                type: array
+                              wwids:
+                                description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                                items:
+                                  type: string
+                                type: array
+                            type: object
+                          flexVolume:
+                            description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                            properties:
+                              driver:
+                                description: driver is the name of the driver to use for this volume.
+                                type: string
+                              fsType:
+                                description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                                type: string
+                              options:
+                                additionalProperties:
+                                  type: string
+                                description: 'options is Optional: this field holds extra command options if any.'
+                                type: object
+                              readOnly:
+                                description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                            required:
+                              - driver
+                            type: object
+                          flocker:
+                            description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                            properties:
+                              datasetName:
+                                description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                                type: string
+                              datasetUUID:
+                                description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                                type: string
+                            type: object
+                          gcePersistentDisk:
+                            description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            properties:
+                              fsType:
+                                description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              partition:
+                                description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                format: int32
+                                type: integer
+                              pdName:
+                                description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                                type: boolean
+                            required:
+                              - pdName
+                            type: object
+                          gitRepo:
+                            description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                            properties:
+                              directory:
+                                description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                                type: string
+                              repository:
+                                description: repository is the URL
+                                type: string
+                              revision:
+                                description: revision is the commit hash for the specified revision.
+                                type: string
+                            required:
+                              - repository
+                            type: object
+                          glusterfs:
+                            description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                            properties:
+                              endpoints:
+                                description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              path:
+                                description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                                type: boolean
+                            required:
+                              - endpoints
+                              - path
+                            type: object
+                          hostPath:
+                            description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            properties:
+                              path:
+                                description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                              type:
+                                description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                                type: string
+                            required:
+                              - path
+                            type: object
+                          iscsi:
+                            description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                            properties:
+                              chapAuthDiscovery:
+                                description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                                type: boolean
+                              chapAuthSession:
+                                description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                                type: boolean
+                              fsType:
+                                description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                                type: string
+                              initiatorName:
+                                description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                                type: string
+                              iqn:
+                                description: iqn is the target iSCSI Qualified Name.
+                                type: string
+                              iscsiInterface:
+                                description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                                type: string
+                              lun:
+                                description: lun represents iSCSI Target Lun number.
+                                format: int32
+                                type: integer
+                              portals:
+                                description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                items:
+                                  type: string
+                                type: array
+                              readOnly:
+                                description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                                type: boolean
+                              secretRef:
+                                description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              targetPortal:
+                                description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                                type: string
+                            required:
+                              - iqn
+                              - lun
+                              - targetPortal
+                            type: object
+                          name:
+                            description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          nfs:
+                            description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            properties:
+                              path:
+                                description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: boolean
+                              server:
+                                description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                                type: string
+                            required:
+                              - path
+                              - server
+                            type: object
+                          persistentVolumeClaim:
+                            description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            properties:
+                              claimName:
+                                description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                                type: string
+                              readOnly:
+                                description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
+                                type: boolean
+                            required:
+                              - claimName
+                            type: object
+                          photonPersistentDisk:
+                            description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              pdID:
+                                description: pdID is the ID that identifies Photon Controller persistent disk
+                                type: string
+                            required:
+                              - pdID
+                            type: object
+                          portworxVolume:
+                            description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              volumeID:
+                                description: volumeID uniquely identifies a Portworx volume
+                                type: string
+                            required:
+                              - volumeID
+                            type: object
+                          projected:
+                            description: projected items for all in one resources secrets, configmaps, and downward API
+                            properties:
+                              defaultMode:
+                                description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                                format: int32
+                                type: integer
+                              sources:
+                                description: sources is the list of volume projections
+                                items:
+                                  description: Projection that may be projected along with other supported volume types
+                                  properties:
+                                    configMap:
+                                      description: configMap information about the configMap data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional specify whether the ConfigMap or its keys must be defined
+                                          type: boolean
+                                      type: object
+                                    downwardAPI:
+                                      description: downwardAPI information about the downwardAPI data to project
+                                      properties:
+                                        items:
+                                          description: Items is a list of DownwardAPIVolume file
+                                          items:
+                                            description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                            properties:
+                                              fieldRef:
+                                                description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                                properties:
+                                                  apiVersion:
+                                                    description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                    type: string
+                                                  fieldPath:
+                                                    description: Path of the field to select in the specified API version.
+                                                    type: string
+                                                required:
+                                                  - fieldPath
+                                                type: object
+                                              mode:
+                                                description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                                type: string
+                                              resourceFieldRef:
+                                                description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                                properties:
+                                                  containerName:
+                                                    description: 'Container name: required for volumes, optional for env vars'
+                                                    type: string
+                                                  divisor:
+                                                    description: Specifies the output format of the exposed resources, defaults to "1"
+                                                    type: string
+                                                  resource:
+                                                    description: 'Required: resource to select'
+                                                    type: string
+                                                required:
+                                                  - resource
+                                                type: object
+                                            required:
+                                              - path
+                                            type: object
+                                          type: array
+                                      type: object
+                                    secret:
+                                      description: secret information about the secret data to project
+                                      properties:
+                                        items:
+                                          description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                          items:
+                                            description: Maps a string key to a path within a volume.
+                                            properties:
+                                              key:
+                                                description: key is the key to project.
+                                                type: string
+                                              mode:
+                                                description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                                format: int32
+                                                type: integer
+                                              path:
+                                                description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                                type: string
+                                            required:
+                                              - key
+                                              - path
+                                            type: object
+                                          type: array
+                                        name:
+                                          description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                          type: string
+                                        optional:
+                                          description: optional field specify whether the Secret or its key must be defined
+                                          type: boolean
+                                      type: object
+                                    serviceAccountToken:
+                                      description: serviceAccountToken is information about the serviceAccountToken data to project
+                                      properties:
+                                        audience:
+                                          description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                          type: string
+                                        expirationSeconds:
+                                          description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                          format: int64
+                                          type: integer
+                                        path:
+                                          description: path is the path relative to the mount point of the file to project the token into.
+                                          type: string
+                                      required:
+                                        - path
+                                      type: object
+                                  type: object
+                                type: array
+                            type: object
+                          quobyte:
+                            description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                            properties:
+                              group:
+                                description: group to map volume access to Default is no group
+                                type: string
+                              readOnly:
+                                description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                                type: boolean
+                              registry:
+                                description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                                type: string
+                              tenant:
+                                description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                                type: string
+                              user:
+                                description: user to map volume access to Defaults to serivceaccount user
+                                type: string
+                              volume:
+                                description: volume is a string that references an already created Quobyte volume by name.
+                                type: string
+                            required:
+                              - registry
+                              - volume
+                            type: object
+                          rbd:
+                            description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                            properties:
+                              fsType:
+                                description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                                type: string
+                              image:
+                                description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              keyring:
+                                description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              monitors:
+                                description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                items:
+                                  type: string
+                                type: array
+                              pool:
+                                description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                              readOnly:
+                                description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: boolean
+                              secretRef:
+                                description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              user:
+                                description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                                type: string
+                            required:
+                              - image
+                              - monitors
+                            type: object
+                          scaleIO:
+                            description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                                type: string
+                              gateway:
+                                description: gateway is the host address of the ScaleIO API Gateway.
+                                type: string
+                              protectionDomain:
+                                description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                                type: string
+                              readOnly:
+                                description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              sslEnabled:
+                                description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                                type: boolean
+                              storageMode:
+                                description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                                type: string
+                              storagePool:
+                                description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                                type: string
+                              system:
+                                description: system is the name of the storage system as configured in ScaleIO.
+                                type: string
+                              volumeName:
+                                description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+                                type: string
+                            required:
+                              - gateway
+                              - secretRef
+                              - system
+                            type: object
+                          secret:
+                            description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            properties:
+                              defaultMode:
+                                description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                format: int32
+                                type: integer
+                              items:
+                                description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                items:
+                                  description: Maps a string key to a path within a volume.
+                                  properties:
+                                    key:
+                                      description: key is the key to project.
+                                      type: string
+                                    mode:
+                                      description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                      format: int32
+                                      type: integer
+                                    path:
+                                      description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                      type: string
+                                  required:
+                                    - key
+                                    - path
+                                  type: object
+                                type: array
+                              optional:
+                                description: optional field specify whether the Secret or its keys must be defined
+                                type: boolean
+                              secretName:
+                                description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                                type: string
+                            type: object
+                          storageos:
+                            description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                            properties:
+                              fsType:
+                                description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              readOnly:
+                                description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                                type: boolean
+                              secretRef:
+                                description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                                properties:
+                                  name:
+                                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                    type: string
+                                type: object
+                              volumeName:
+                                description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                                type: string
+                              volumeNamespace:
+                                description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                                type: string
+                            type: object
+                          vsphereVolume:
+                            description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                            properties:
+                              fsType:
+                                description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                                type: string
+                              storagePolicyID:
+                                description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                                type: string
+                              storagePolicyName:
+                                description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                                type: string
+                              volumePath:
+                                description: volumePath is the path that identifies vSphere volume vmdk
+                                type: string
+                            required:
+                              - volumePath
+                            type: object
+                        required:
+                          - name
+                        type: object
+                      type: array
                     ingestion:
                       description: Ingestion settings for Druid like S3
                       nullable: true
@@ -2902,1082 +3978,6 @@ spec:
                   required:
                     - roleGroups
                   type: object
-                extraVolumes:
-                  description: Extra volumes to mount into every container, this can be useful to for example make client certificates, keytabs or similar things available to processors These volumes will be mounted into all pods
-                  items:
-                    description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
-                    properties:
-                      awsElasticBlockStore:
-                        description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                        properties:
-                          fsType:
-                            description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                            type: string
-                          partition:
-                            description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
-                            format: int32
-                            type: integer
-                          readOnly:
-                            description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                            type: boolean
-                          volumeID:
-                            description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
-                            type: string
-                        required:
-                          - volumeID
-                        type: object
-                      azureDisk:
-                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
-                        properties:
-                          cachingMode:
-                            description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
-                            type: string
-                          diskName:
-                            description: diskName is the Name of the data disk in the blob storage
-                            type: string
-                          diskURI:
-                            description: diskURI is the URI of data disk in the blob storage
-                            type: string
-                          fsType:
-                            description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          kind:
-                            description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
-                            type: string
-                          readOnly:
-                            description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                        required:
-                          - diskName
-                          - diskURI
-                        type: object
-                      azureFile:
-                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
-                        properties:
-                          readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                          secretName:
-                            description: secretName is the  name of secret that contains Azure Storage Account Name and Key
-                            type: string
-                          shareName:
-                            description: shareName is the azure share Name
-                            type: string
-                        required:
-                          - secretName
-                          - shareName
-                        type: object
-                      cephfs:
-                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
-                        properties:
-                          monitors:
-                            description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            items:
-                              type: string
-                            type: array
-                          path:
-                            description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
-                            type: string
-                          readOnly:
-                            description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            type: boolean
-                          secretFile:
-                            description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            type: string
-                          secretRef:
-                            description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                            type: object
-                          user:
-                            description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
-                            type: string
-                        required:
-                          - monitors
-                        type: object
-                      cinder:
-                        description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                        properties:
-                          fsType:
-                            description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                            type: string
-                          readOnly:
-                            description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                            type: boolean
-                          secretRef:
-                            description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                            type: object
-                          volumeID:
-                            description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
-                            type: string
-                        required:
-                          - volumeID
-                        type: object
-                      configMap:
-                        description: configMap represents a configMap that should populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: key is the key to project.
-                                  type: string
-                                mode:
-                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          name:
-                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                            type: string
-                          optional:
-                            description: optional specify whether the ConfigMap or its keys must be defined
-                            type: boolean
-                        type: object
-                      csi:
-                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
-                        properties:
-                          driver:
-                            description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
-                            type: string
-                          fsType:
-                            description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
-                            type: string
-                          nodePublishSecretRef:
-                            description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                            type: object
-                          readOnly:
-                            description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
-                            type: boolean
-                          volumeAttributes:
-                            additionalProperties:
-                              type: string
-                            description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
-                            type: object
-                        required:
-                          - driver
-                        type: object
-                      downwardAPI:
-                        description: downwardAPI represents downward API about the pod that should populate this volume
-                        properties:
-                          defaultMode:
-                            description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: Items is a list of downward API volume file
-                            items:
-                              description: DownwardAPIVolumeFile represents information to create the file containing the pod field
-                              properties:
-                                fieldRef:
-                                  description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
-                                  properties:
-                                    apiVersion:
-                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                      type: string
-                                    fieldPath:
-                                      description: Path of the field to select in the specified API version.
-                                      type: string
-                                  required:
-                                    - fieldPath
-                                  type: object
-                                mode:
-                                  description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
-                                  type: string
-                                resourceFieldRef:
-                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
-                                  properties:
-                                    containerName:
-                                      description: 'Container name: required for volumes, optional for env vars'
-                                      type: string
-                                    divisor:
-                                      description: Specifies the output format of the exposed resources, defaults to "1"
-                                      type: string
-                                    resource:
-                                      description: 'Required: resource to select'
-                                      type: string
-                                  required:
-                                    - resource
-                                  type: object
-                              required:
-                                - path
-                              type: object
-                            type: array
-                        type: object
-                      emptyDir:
-                        description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                        properties:
-                          medium:
-                            description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
-                            type: string
-                          sizeLimit:
-                            description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
-                            type: string
-                        type: object
-                      ephemeral:
-                        description: |-
-                          ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
-
-                          Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
-                             tracking are needed,
-                          c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
-                             a PersistentVolumeClaim (see EphemeralVolumeSource for more
-                             information on the connection between this volume type
-                             and PersistentVolumeClaim).
-
-                          Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
-
-                          Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
-
-                          A pod can use both types of ephemeral volumes and persistent volumes at the same time.
-                        properties:
-                          volumeClaimTemplate:
-                            description: |-
-                              Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
-
-                              An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
-
-                              This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
-
-                              Required, must not be nil.
-                            properties:
-                              metadata:
-                                description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
-                                properties:
-                                  annotations:
-                                    additionalProperties:
-                                      type: string
-                                    description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
-                                    type: object
-                                  creationTimestamp:
-                                    description: |-
-                                      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
-
-                                      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                                    format: date-time
-                                    type: string
-                                  deletionGracePeriodSeconds:
-                                    description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
-                                    format: int64
-                                    type: integer
-                                  deletionTimestamp:
-                                    description: |-
-                                      DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
-
-                                      Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                                    format: date-time
-                                    type: string
-                                  finalizers:
-                                    description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
-                                    items:
-                                      type: string
-                                    type: array
-                                  generateName:
-                                    description: |-
-                                      GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
-
-                                      If this field is specified and the generated name exists, the server will return a 409.
-
-                                      Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
-                                    type: string
-                                  generation:
-                                    description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
-                                    format: int64
-                                    type: integer
-                                  labels:
-                                    additionalProperties:
-                                      type: string
-                                    description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
-                                    type: object
-                                  managedFields:
-                                    description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
-                                    items:
-                                      description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
-                                      properties:
-                                        apiVersion:
-                                          description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
-                                          type: string
-                                        fieldsType:
-                                          description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
-                                          type: string
-                                        fieldsV1:
-                                          description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
-                                          type: object
-                                        manager:
-                                          description: Manager is an identifier of the workflow managing these fields.
-                                          type: string
-                                        operation:
-                                          description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
-                                          type: string
-                                        subresource:
-                                          description: Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
-                                          type: string
-                                        time:
-                                          description: Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.
-                                          format: date-time
-                                          type: string
-                                      type: object
-                                    type: array
-                                  name:
-                                    description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                    type: string
-                                  namespace:
-                                    description: |-
-                                      Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
-
-                                      Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
-                                    type: string
-                                  ownerReferences:
-                                    description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
-                                    items:
-                                      description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
-                                      properties:
-                                        apiVersion:
-                                          description: API version of the referent.
-                                          type: string
-                                        blockOwnerDeletion:
-                                          description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
-                                          type: boolean
-                                        controller:
-                                          description: If true, this reference points to the managing controller.
-                                          type: boolean
-                                        kind:
-                                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                                          type: string
-                                        name:
-                                          description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
-                                          type: string
-                                        uid:
-                                          description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
-                                          type: string
-                                      required:
-                                        - apiVersion
-                                        - kind
-                                        - name
-                                        - uid
-                                      type: object
-                                    type: array
-                                  resourceVersion:
-                                    description: |-
-                                      An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
-
-                                      Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
-                                    type: string
-                                  selfLink:
-                                    description: 'Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.'
-                                    type: string
-                                  uid:
-                                    description: |-
-                                      UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
-
-                                      Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
-                                    type: string
-                                type: object
-                              spec:
-                                description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
-                                properties:
-                                  accessModes:
-                                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
-                                    items:
-                                      type: string
-                                    type: array
-                                  dataSource:
-                                    description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
-                                    properties:
-                                      apiGroup:
-                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
-                                        type: string
-                                      kind:
-                                        description: Kind is the type of resource being referenced
-                                        type: string
-                                      name:
-                                        description: Name is the name of resource being referenced
-                                        type: string
-                                    required:
-                                      - kind
-                                      - name
-                                    type: object
-                                  dataSourceRef:
-                                    description: |-
-                                      dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef
-                                        allows any non-core object, as well as PersistentVolumeClaim objects.
-                                      * While dataSource ignores disallowed values (dropping them), dataSourceRef
-                                        preserves all values, and generates an error if a disallowed value is
-                                        specified.
-                                      * While dataSource only allows local objects, dataSourceRef allows objects
-                                        in any namespaces.
-                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
-                                    properties:
-                                      apiGroup:
-                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
-                                        type: string
-                                      kind:
-                                        description: Kind is the type of resource being referenced
-                                        type: string
-                                      name:
-                                        description: Name is the name of resource being referenced
-                                        type: string
-                                      namespace:
-                                        description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
-                                        type: string
-                                    required:
-                                      - kind
-                                      - name
-                                    type: object
-                                  resources:
-                                    description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
-                                    properties:
-                                      claims:
-                                        description: |-
-                                          Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.
-
-                                          This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
-
-                                          This field is immutable.
-                                        items:
-                                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
-                                          properties:
-                                            name:
-                                              description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
-                                              type: string
-                                          required:
-                                            - name
-                                          type: object
-                                        type: array
-                                      limits:
-                                        additionalProperties:
-                                          description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
-                                          type: string
-                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                        type: object
-                                      requests:
-                                        additionalProperties:
-                                          description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
-                                          type: string
-                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
-                                        type: object
-                                    type: object
-                                  selector:
-                                    description: selector is a label query over volumes to consider for binding.
-                                    properties:
-                                      matchExpressions:
-                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
-                                        items:
-                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
-                                          properties:
-                                            key:
-                                              description: key is the label key that the selector applies to.
-                                              type: string
-                                            operator:
-                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
-                                              type: string
-                                            values:
-                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
-                                              items:
-                                                type: string
-                                              type: array
-                                          required:
-                                            - key
-                                            - operator
-                                          type: object
-                                        type: array
-                                      matchLabels:
-                                        additionalProperties:
-                                          type: string
-                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
-                                        type: object
-                                    type: object
-                                  storageClassName:
-                                    description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
-                                    type: string
-                                  volumeMode:
-                                    description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
-                                    type: string
-                                  volumeName:
-                                    description: volumeName is the binding reference to the PersistentVolume backing this claim.
-                                    type: string
-                                type: object
-                            required:
-                              - spec
-                            type: object
-                        type: object
-                      fc:
-                        description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
-                        properties:
-                          fsType:
-                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          lun:
-                            description: 'lun is Optional: FC target lun number'
-                            format: int32
-                            type: integer
-                          readOnly:
-                            description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                            type: boolean
-                          targetWWNs:
-                            description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
-                            items:
-                              type: string
-                            type: array
-                          wwids:
-                            description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
-                            items:
-                              type: string
-                            type: array
-                        type: object
-                      flexVolume:
-                        description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
-                        properties:
-                          driver:
-                            description: driver is the name of the driver to use for this volume.
-                            type: string
-                          fsType:
-                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
-                            type: string
-                          options:
-                            additionalProperties:
-                              type: string
-                            description: 'options is Optional: this field holds extra command options if any.'
-                            type: object
-                          readOnly:
-                            description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
-                            type: boolean
-                          secretRef:
-                            description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                            type: object
-                        required:
-                          - driver
-                        type: object
-                      flocker:
-                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
-                        properties:
-                          datasetName:
-                            description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
-                            type: string
-                          datasetUUID:
-                            description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
-                            type: string
-                        type: object
-                      gcePersistentDisk:
-                        description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                        properties:
-                          fsType:
-                            description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                            type: string
-                          partition:
-                            description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                            format: int32
-                            type: integer
-                          pdName:
-                            description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                            type: string
-                          readOnly:
-                            description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
-                            type: boolean
-                        required:
-                          - pdName
-                        type: object
-                      gitRepo:
-                        description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
-                        properties:
-                          directory:
-                            description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
-                            type: string
-                          repository:
-                            description: repository is the URL
-                            type: string
-                          revision:
-                            description: revision is the commit hash for the specified revision.
-                            type: string
-                        required:
-                          - repository
-                        type: object
-                      glusterfs:
-                        description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
-                        properties:
-                          endpoints:
-                            description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                            type: string
-                          path:
-                            description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                            type: string
-                          readOnly:
-                            description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
-                            type: boolean
-                        required:
-                          - endpoints
-                          - path
-                        type: object
-                      hostPath:
-                        description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                        properties:
-                          path:
-                            description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                            type: string
-                          type:
-                            description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
-                            type: string
-                        required:
-                          - path
-                        type: object
-                      iscsi:
-                        description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
-                        properties:
-                          chapAuthDiscovery:
-                            description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
-                            type: boolean
-                          chapAuthSession:
-                            description: chapAuthSession defines whether support iSCSI Session CHAP authentication
-                            type: boolean
-                          fsType:
-                            description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
-                            type: string
-                          initiatorName:
-                            description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
-                            type: string
-                          iqn:
-                            description: iqn is the target iSCSI Qualified Name.
-                            type: string
-                          iscsiInterface:
-                            description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
-                            type: string
-                          lun:
-                            description: lun represents iSCSI Target Lun number.
-                            format: int32
-                            type: integer
-                          portals:
-                            description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-                            items:
-                              type: string
-                            type: array
-                          readOnly:
-                            description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
-                            type: boolean
-                          secretRef:
-                            description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                            type: object
-                          targetPortal:
-                            description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
-                            type: string
-                        required:
-                          - iqn
-                          - lun
-                          - targetPortal
-                        type: object
-                      name:
-                        description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                        type: string
-                      nfs:
-                        description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                        properties:
-                          path:
-                            description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                            type: string
-                          readOnly:
-                            description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                            type: boolean
-                          server:
-                            description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
-                            type: string
-                        required:
-                          - path
-                          - server
-                        type: object
-                      persistentVolumeClaim:
-                        description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                        properties:
-                          claimName:
-                            description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
-                            type: string
-                          readOnly:
-                            description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
-                            type: boolean
-                        required:
-                          - claimName
-                        type: object
-                      photonPersistentDisk:
-                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
-                        properties:
-                          fsType:
-                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          pdID:
-                            description: pdID is the ID that identifies Photon Controller persistent disk
-                            type: string
-                        required:
-                          - pdID
-                        type: object
-                      portworxVolume:
-                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
-                        properties:
-                          fsType:
-                            description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                          volumeID:
-                            description: volumeID uniquely identifies a Portworx volume
-                            type: string
-                        required:
-                          - volumeID
-                        type: object
-                      projected:
-                        description: projected items for all in one resources secrets, configmaps, and downward API
-                        properties:
-                          defaultMode:
-                            description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
-                            format: int32
-                            type: integer
-                          sources:
-                            description: sources is the list of volume projections
-                            items:
-                              description: Projection that may be projected along with other supported volume types
-                              properties:
-                                configMap:
-                                  description: configMap information about the configMap data to project
-                                  properties:
-                                    items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within a volume.
-                                        properties:
-                                          key:
-                                            description: key is the key to project.
-                                            type: string
-                                          mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-                                            type: string
-                                        required:
-                                          - key
-                                          - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                      type: string
-                                    optional:
-                                      description: optional specify whether the ConfigMap or its keys must be defined
-                                      type: boolean
-                                  type: object
-                                downwardAPI:
-                                  description: downwardAPI information about the downwardAPI data to project
-                                  properties:
-                                    items:
-                                      description: Items is a list of DownwardAPIVolume file
-                                      items:
-                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
-                                        properties:
-                                          fieldRef:
-                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
-                                            properties:
-                                              apiVersion:
-                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
-                                                type: string
-                                              fieldPath:
-                                                description: Path of the field to select in the specified API version.
-                                                type: string
-                                            required:
-                                              - fieldPath
-                                            type: object
-                                          mode:
-                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
-                                            type: string
-                                          resourceFieldRef:
-                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
-                                            properties:
-                                              containerName:
-                                                description: 'Container name: required for volumes, optional for env vars'
-                                                type: string
-                                              divisor:
-                                                description: Specifies the output format of the exposed resources, defaults to "1"
-                                                type: string
-                                              resource:
-                                                description: 'Required: resource to select'
-                                                type: string
-                                            required:
-                                              - resource
-                                            type: object
-                                        required:
-                                          - path
-                                        type: object
-                                      type: array
-                                  type: object
-                                secret:
-                                  description: secret information about the secret data to project
-                                  properties:
-                                    items:
-                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
-                                      items:
-                                        description: Maps a string key to a path within a volume.
-                                        properties:
-                                          key:
-                                            description: key is the key to project.
-                                            type: string
-                                          mode:
-                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                                            format: int32
-                                            type: integer
-                                          path:
-                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-                                            type: string
-                                        required:
-                                          - key
-                                          - path
-                                        type: object
-                                      type: array
-                                    name:
-                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                      type: string
-                                    optional:
-                                      description: optional field specify whether the Secret or its key must be defined
-                                      type: boolean
-                                  type: object
-                                serviceAccountToken:
-                                  description: serviceAccountToken is information about the serviceAccountToken data to project
-                                  properties:
-                                    audience:
-                                      description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
-                                      type: string
-                                    expirationSeconds:
-                                      description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
-                                      format: int64
-                                      type: integer
-                                    path:
-                                      description: path is the path relative to the mount point of the file to project the token into.
-                                      type: string
-                                  required:
-                                    - path
-                                  type: object
-                              type: object
-                            type: array
-                        type: object
-                      quobyte:
-                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
-                        properties:
-                          group:
-                            description: group to map volume access to Default is no group
-                            type: string
-                          readOnly:
-                            description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
-                            type: boolean
-                          registry:
-                            description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
-                            type: string
-                          tenant:
-                            description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
-                            type: string
-                          user:
-                            description: user to map volume access to Defaults to serivceaccount user
-                            type: string
-                          volume:
-                            description: volume is a string that references an already created Quobyte volume by name.
-                            type: string
-                        required:
-                          - registry
-                          - volume
-                        type: object
-                      rbd:
-                        description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
-                        properties:
-                          fsType:
-                            description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
-                            type: string
-                          image:
-                            description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: string
-                          keyring:
-                            description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: string
-                          monitors:
-                            description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            items:
-                              type: string
-                            type: array
-                          pool:
-                            description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: string
-                          readOnly:
-                            description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: boolean
-                          secretRef:
-                            description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                            type: object
-                          user:
-                            description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
-                            type: string
-                        required:
-                          - image
-                          - monitors
-                        type: object
-                      scaleIO:
-                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
-                        properties:
-                          fsType:
-                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
-                            type: string
-                          gateway:
-                            description: gateway is the host address of the ScaleIO API Gateway.
-                            type: string
-                          protectionDomain:
-                            description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
-                            type: string
-                          readOnly:
-                            description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                          secretRef:
-                            description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                            type: object
-                          sslEnabled:
-                            description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
-                            type: boolean
-                          storageMode:
-                            description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
-                            type: string
-                          storagePool:
-                            description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
-                            type: string
-                          system:
-                            description: system is the name of the storage system as configured in ScaleIO.
-                            type: string
-                          volumeName:
-                            description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
-                            type: string
-                        required:
-                          - gateway
-                          - secretRef
-                          - system
-                        type: object
-                      secret:
-                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                        properties:
-                          defaultMode:
-                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                            format: int32
-                            type: integer
-                          items:
-                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
-                            items:
-                              description: Maps a string key to a path within a volume.
-                              properties:
-                                key:
-                                  description: key is the key to project.
-                                  type: string
-                                mode:
-                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
-                                  format: int32
-                                  type: integer
-                                path:
-                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
-                                  type: string
-                              required:
-                                - key
-                                - path
-                              type: object
-                            type: array
-                          optional:
-                            description: optional field specify whether the Secret or its keys must be defined
-                            type: boolean
-                          secretName:
-                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
-                            type: string
-                        type: object
-                      storageos:
-                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
-                        properties:
-                          fsType:
-                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          readOnly:
-                            description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
-                            type: boolean
-                          secretRef:
-                            description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
-                            properties:
-                              name:
-                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                                type: string
-                            type: object
-                          volumeName:
-                            description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
-                            type: string
-                          volumeNamespace:
-                            description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
-                            type: string
-                        type: object
-                      vsphereVolume:
-                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
-                        properties:
-                          fsType:
-                            description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
-                            type: string
-                          storagePolicyID:
-                            description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
-                            type: string
-                          storagePolicyName:
-                            description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
-                            type: string
-                          volumePath:
-                            description: volumePath is the path that identifies vSphere volume vmdk
-                            type: string
-                        required:
-                          - volumePath
-                        type: object
-                    required:
-                      - name
-                    type: object
-                  type: array
                 historicals:
                   description: Configuration of the historical role
                   properties:

--- a/deploy/helm/druid-operator/crds/crds.yaml
+++ b/deploy/helm/druid-operator/crds/crds.yaml
@@ -2903,7 +2903,7 @@ spec:
                     - roleGroups
                   type: object
                 extraVolumes:
-                  description: Extra volumes to mount into every container, this can be useful to for example make client certificates, keytabs or similar things available to processors These volumes will be mounted into the MiddleManager pods, as these are the ones actually running ingestion tasks, for which this will be needed
+                  description: Extra volumes to mount into every container, this can be useful to for example make client certificates, keytabs or similar things available to processors These volumes will be mounted into all pods
                   items:
                     description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                     properties:

--- a/deploy/helm/druid-operator/crds/crds.yaml
+++ b/deploy/helm/druid-operator/crds/crds.yaml
@@ -2902,6 +2902,1082 @@ spec:
                   required:
                     - roleGroups
                   type: object
+                extraVolumes:
+                  description: Extra volumes to mount into every container, this can be useful to for example make client certificates, keytabs or similar things available to processors These volumes will be mounted into the MiddleManager pods, as these are the ones actually running ingestion tasks, for which this will be needed
+                  items:
+                    description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
+                    properties:
+                      awsElasticBlockStore:
+                        description: 'awsElasticBlockStore represents an AWS Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                          partition:
+                            description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty).'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'readOnly value true will force the readOnly setting in VolumeMounts. More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: boolean
+                          volumeID:
+                            description: 'volumeID is unique ID of the persistent disk resource in AWS (Amazon EBS volume). More info: https://kubernetes.io/docs/concepts/storage/volumes#awselasticblockstore'
+                            type: string
+                        required:
+                          - volumeID
+                        type: object
+                      azureDisk:
+                        description: azureDisk represents an Azure Data Disk mount on the host and bind mount to the pod.
+                        properties:
+                          cachingMode:
+                            description: 'cachingMode is the Host Caching mode: None, Read Only, Read Write.'
+                            type: string
+                          diskName:
+                            description: diskName is the Name of the data disk in the blob storage
+                            type: string
+                          diskURI:
+                            description: diskURI is the URI of data disk in the blob storage
+                            type: string
+                          fsType:
+                            description: fsType is Filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          kind:
+                            description: 'kind expected values are Shared: multiple blob disks per storage account  Dedicated: single blob disk per storage account  Managed: azure managed data disk (only in managed availability set). defaults to shared'
+                            type: string
+                          readOnly:
+                            description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                        required:
+                          - diskName
+                          - diskURI
+                        type: object
+                      azureFile:
+                        description: azureFile represents an Azure File Service mount on the host and bind mount to the pod.
+                        properties:
+                          readOnly:
+                            description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretName:
+                            description: secretName is the  name of secret that contains Azure Storage Account Name and Key
+                            type: string
+                          shareName:
+                            description: shareName is the azure share Name
+                            type: string
+                        required:
+                          - secretName
+                          - shareName
+                        type: object
+                      cephfs:
+                        description: cephFS represents a Ceph FS mount on the host that shares a pod's lifetime
+                        properties:
+                          monitors:
+                            description: 'monitors is Required: Monitors is a collection of Ceph monitors More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          path:
+                            description: 'path is Optional: Used as the mounted root, rather than the full Ceph tree, default is /'
+                            type: string
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: boolean
+                          secretFile:
+                            description: 'secretFile is Optional: SecretFile is the path to key ring for User, default is /etc/ceph/user.secret More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                          secretRef:
+                            description: 'secretRef is Optional: SecretRef is reference to the authentication secret for User, default is empty. More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          user:
+                            description: 'user is optional: User is the rados user name, default is admin More info: https://examples.k8s.io/volumes/cephfs/README.md#how-to-use-it'
+                            type: string
+                        required:
+                          - monitors
+                        type: object
+                      cinder:
+                        description: 'cinder represents a cinder volume attached and mounted on kubelets host machine. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: string
+                          readOnly:
+                            description: 'readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is optional: points to a secret object containing parameters used to connect to OpenStack.'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          volumeID:
+                            description: 'volumeID used to identify the volume in cinder. More info: https://examples.k8s.io/mysql-cinder-pd/README.md'
+                            type: string
+                        required:
+                          - volumeID
+                        type: object
+                      configMap:
+                        description: configMap represents a configMap that should populate this volume
+                        properties:
+                          defaultMode:
+                            description: 'defaultMode is optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          items:
+                            description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                  type: string
+                              required:
+                                - key
+                                - path
+                              type: object
+                            type: array
+                          name:
+                            description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                            type: string
+                          optional:
+                            description: optional specify whether the ConfigMap or its keys must be defined
+                            type: boolean
+                        type: object
+                      csi:
+                        description: csi (Container Storage Interface) represents ephemeral storage that is handled by certain external CSI drivers (Beta feature).
+                        properties:
+                          driver:
+                            description: driver is the name of the CSI driver that handles this volume. Consult with your admin for the correct name as registered in the cluster.
+                            type: string
+                          fsType:
+                            description: fsType to mount. Ex. "ext4", "xfs", "ntfs". If not provided, the empty value is passed to the associated CSI driver which will determine the default filesystem to apply.
+                            type: string
+                          nodePublishSecretRef:
+                            description: nodePublishSecretRef is a reference to the secret object containing sensitive information to pass to the CSI driver to complete the CSI NodePublishVolume and NodeUnpublishVolume calls. This field is optional, and  may be empty if no secret is required. If the secret object contains more than one secret, all secret references are passed.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          readOnly:
+                            description: readOnly specifies a read-only configuration for the volume. Defaults to false (read/write).
+                            type: boolean
+                          volumeAttributes:
+                            additionalProperties:
+                              type: string
+                            description: volumeAttributes stores driver-specific properties that are passed to the CSI driver. Consult your driver's documentation for supported values.
+                            type: object
+                        required:
+                          - driver
+                        type: object
+                      downwardAPI:
+                        description: downwardAPI represents downward API about the pod that should populate this volume
+                        properties:
+                          defaultMode:
+                            description: 'Optional: mode bits to use on created files by default. Must be a Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          items:
+                            description: Items is a list of downward API volume file
+                            items:
+                              description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                              properties:
+                                fieldRef:
+                                  description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the specified API version.
+                                      type: string
+                                  required:
+                                    - fieldPath
+                                  type: object
+                                mode:
+                                  description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                  type: string
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes, optional for env vars'
+                                      type: string
+                                    divisor:
+                                      description: Specifies the output format of the exposed resources, defaults to "1"
+                                      type: string
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                    - resource
+                                  type: object
+                              required:
+                                - path
+                              type: object
+                            type: array
+                        type: object
+                      emptyDir:
+                        description: 'emptyDir represents a temporary directory that shares a pod''s lifetime. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                        properties:
+                          medium:
+                            description: 'medium represents what type of storage medium should back this directory. The default is "" which means to use the node''s default medium. Must be an empty string (default) or Memory. More info: https://kubernetes.io/docs/concepts/storage/volumes#emptydir'
+                            type: string
+                          sizeLimit:
+                            description: 'sizeLimit is the total amount of local storage required for this EmptyDir volume. The size limit is also applicable for memory medium. The maximum usage on memory medium EmptyDir would be the minimum value between the SizeLimit specified here and the sum of memory limits of all containers in a pod. The default is nil which means that the limit is undefined. More info: http://kubernetes.io/docs/user-guide/volumes#emptydir'
+                            type: string
+                        type: object
+                      ephemeral:
+                        description: |-
+                          ephemeral represents a volume that is handled by a cluster storage driver. The volume's lifecycle is tied to the pod that defines it - it will be created before the pod starts, and deleted when the pod is removed.
+
+                          Use this if: a) the volume is only needed while the pod runs, b) features of normal volumes like restoring from snapshot or capacity
+                             tracking are needed,
+                          c) the storage driver is specified through a storage class, and d) the storage driver supports dynamic volume provisioning through
+                             a PersistentVolumeClaim (see EphemeralVolumeSource for more
+                             information on the connection between this volume type
+                             and PersistentVolumeClaim).
+
+                          Use PersistentVolumeClaim or one of the vendor-specific APIs for volumes that persist for longer than the lifecycle of an individual pod.
+
+                          Use CSI for light-weight local ephemeral volumes if the CSI driver is meant to be used that way - see the documentation of the driver for more information.
+
+                          A pod can use both types of ephemeral volumes and persistent volumes at the same time.
+                        properties:
+                          volumeClaimTemplate:
+                            description: |-
+                              Will be used to create a stand-alone PVC to provision the volume. The pod in which this EphemeralVolumeSource is embedded will be the owner of the PVC, i.e. the PVC will be deleted together with the pod.  The name of the PVC will be `<pod name>-<volume name>` where `<volume name>` is the name from the `PodSpec.Volumes` array entry. Pod validation will reject the pod if the concatenated name is not valid for a PVC (for example, too long).
+
+                              An existing PVC with that name that is not owned by the pod will *not* be used for the pod to avoid using an unrelated volume by mistake. Starting the pod is then blocked until the unrelated PVC is removed. If such a pre-created PVC is meant to be used by the pod, the PVC has to updated with an owner reference to the pod once the pod exists. Normally this should not be necessary, but it may be useful when manually reconstructing a broken cluster.
+
+                              This field is read-only and no changes will be made by Kubernetes to the PVC after it has been created.
+
+                              Required, must not be nil.
+                            properties:
+                              metadata:
+                                description: May contain labels and annotations that will be copied into the PVC when creating it. No other fields are allowed and will be rejected during validation.
+                                properties:
+                                  annotations:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'Annotations is an unstructured key value map stored with a resource that may be set by external tools to store and retrieve arbitrary metadata. They are not queryable and should be preserved when modifying objects. More info: http://kubernetes.io/docs/user-guide/annotations'
+                                    type: object
+                                  creationTimestamp:
+                                    description: |-
+                                      CreationTimestamp is a timestamp representing the server time when this object was created. It is not guaranteed to be set in happens-before order across separate operations. Clients may not set this value. It is represented in RFC3339 form and is in UTC.
+
+                                      Populated by the system. Read-only. Null for lists. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                    format: date-time
+                                    type: string
+                                  deletionGracePeriodSeconds:
+                                    description: Number of seconds allowed for this object to gracefully terminate before it will be removed from the system. Only set when deletionTimestamp is also set. May only be shortened. Read-only.
+                                    format: int64
+                                    type: integer
+                                  deletionTimestamp:
+                                    description: |-
+                                      DeletionTimestamp is RFC 3339 date and time at which this resource will be deleted. This field is set by the server when a graceful deletion is requested by the user, and is not directly settable by a client. The resource is expected to be deleted (no longer visible from resource lists, and not reachable by name) after the time in this field, once the finalizers list is empty. As long as the finalizers list contains items, deletion is blocked. Once the deletionTimestamp is set, this value may not be unset or be set further into the future, although it may be shortened or the resource may be deleted prior to this time. For example, a user may request that a pod is deleted in 30 seconds. The Kubelet will react by sending a graceful termination signal to the containers in the pod. After that 30 seconds, the Kubelet will send a hard termination signal (SIGKILL) to the container and after cleanup, remove the pod from the API. In the presence of network partitions, this object may still exist after this timestamp, until an administrator or automated process can determine the resource is fully terminated. If not set, graceful deletion of the object has not been requested.
+
+                                      Populated by the system when a graceful deletion is requested. Read-only. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                                    format: date-time
+                                    type: string
+                                  finalizers:
+                                    description: Must be empty before the object is deleted from the registry. Each entry is an identifier for the responsible component that will remove the entry from the list. If the deletionTimestamp of the object is non-nil, entries in this list can only be removed. Finalizers may be processed and removed in any order.  Order is NOT enforced because it introduces significant risk of stuck finalizers. finalizers is a shared field, any actor with permission can reorder it. If the finalizer list is processed in order, then this can lead to a situation in which the component responsible for the first finalizer in the list is waiting for a signal (field value, external system, or other) produced by a component responsible for a finalizer later in the list, resulting in a deadlock. Without enforced ordering finalizers are free to order amongst themselves and are not vulnerable to ordering changes in the list.
+                                    items:
+                                      type: string
+                                    type: array
+                                  generateName:
+                                    description: |-
+                                      GenerateName is an optional prefix, used by the server, to generate a unique name ONLY IF the Name field has not been provided. If this field is used, the name returned to the client will be different than the name passed. This value will also be combined with a unique suffix. The provided value has the same validation rules as the Name field, and may be truncated by the length of the suffix required to make the value unique on the server.
+
+                                      If this field is specified and the generated name exists, the server will return a 409.
+
+                                      Applied only if Name is not specified. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#idempotency
+                                    type: string
+                                  generation:
+                                    description: A sequence number representing a specific generation of the desired state. Populated by the system. Read-only.
+                                    format: int64
+                                    type: integer
+                                  labels:
+                                    additionalProperties:
+                                      type: string
+                                    description: 'Map of string keys and values that can be used to organize and categorize (scope and select) objects. May match selectors of replication controllers and services. More info: http://kubernetes.io/docs/user-guide/labels'
+                                    type: object
+                                  managedFields:
+                                    description: ManagedFields maps workflow-id and version to the set of fields that are managed by that workflow. This is mostly for internal housekeeping, and users typically shouldn't need to set or understand this field. A workflow can be the user's name, a controller's name, or the name of a specific apply path like "ci-cd". The set of fields is always in the version that the workflow used when modifying the object.
+                                    items:
+                                      description: ManagedFieldsEntry is a workflow-id, a FieldSet and the group version of the resource that the fieldset applies to.
+                                      properties:
+                                        apiVersion:
+                                          description: APIVersion defines the version of this resource that this field set applies to. The format is "group/version" just like the top-level APIVersion field. It is necessary to track the version of a field set because it cannot be automatically converted.
+                                          type: string
+                                        fieldsType:
+                                          description: 'FieldsType is the discriminator for the different fields format and version. There is currently only one possible value: "FieldsV1"'
+                                          type: string
+                                        fieldsV1:
+                                          description: FieldsV1 holds the first JSON version format as described in the "FieldsV1" type.
+                                          type: object
+                                        manager:
+                                          description: Manager is an identifier of the workflow managing these fields.
+                                          type: string
+                                        operation:
+                                          description: Operation is the type of operation which lead to this ManagedFieldsEntry being created. The only valid values for this field are 'Apply' and 'Update'.
+                                          type: string
+                                        subresource:
+                                          description: Subresource is the name of the subresource used to update that object, or empty string if the object was updated through the main resource. The value of this field is used to distinguish between managers, even if they share the same name. For example, a status update will be distinct from a regular update using the same manager name. Note that the APIVersion field is not related to the Subresource field and it always corresponds to the version of the main resource.
+                                          type: string
+                                        time:
+                                          description: Time is the timestamp of when the ManagedFields entry was added. The timestamp will also be updated if a field is added, the manager changes any of the owned fields value or removes a field. The timestamp does not update when a field is removed from the entry because another manager took it over.
+                                          format: date-time
+                                          type: string
+                                      type: object
+                                    type: array
+                                  name:
+                                    description: 'Name must be unique within a namespace. Is required when creating resources, although some resources may allow a client to request the generation of an appropriate name automatically. Name is primarily intended for creation idempotence and configuration definition. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                    type: string
+                                  namespace:
+                                    description: |-
+                                      Namespace defines the space within which each name must be unique. An empty namespace is equivalent to the "default" namespace, but "default" is the canonical representation. Not all objects are required to be scoped to a namespace - the value of this field for those objects will be empty.
+
+                                      Must be a DNS_LABEL. Cannot be updated. More info: http://kubernetes.io/docs/user-guide/namespaces
+                                    type: string
+                                  ownerReferences:
+                                    description: List of objects depended by this object. If ALL objects in the list have been deleted, this object will be garbage collected. If this object is managed by a controller, then an entry in this list will point to this controller, with the controller field set to true. There cannot be more than one managing controller.
+                                    items:
+                                      description: OwnerReference contains enough information to let you identify an owning object. An owning object must be in the same namespace as the dependent, or be cluster-scoped, so there is no namespace field.
+                                      properties:
+                                        apiVersion:
+                                          description: API version of the referent.
+                                          type: string
+                                        blockOwnerDeletion:
+                                          description: If true, AND if the owner has the "foregroundDeletion" finalizer, then the owner cannot be deleted from the key-value store until this reference is removed. See https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion for how the garbage collector interacts with this field and enforces the foreground deletion. Defaults to false. To set this field, a user needs "delete" permission of the owner, otherwise 422 (Unprocessable Entity) will be returned.
+                                          type: boolean
+                                        controller:
+                                          description: If true, this reference points to the managing controller.
+                                          type: boolean
+                                        kind:
+                                          description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                          type: string
+                                        name:
+                                          description: 'Name of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                                          type: string
+                                        uid:
+                                          description: 'UID of the referent. More info: http://kubernetes.io/docs/user-guide/identifiers#uids'
+                                          type: string
+                                      required:
+                                        - apiVersion
+                                        - kind
+                                        - name
+                                        - uid
+                                      type: object
+                                    type: array
+                                  resourceVersion:
+                                    description: |-
+                                      An opaque value that represents the internal version of this object that can be used by clients to determine when objects have changed. May be used for optimistic concurrency, change detection, and the watch operation on a resource or set of resources. Clients must treat these values as opaque and passed unmodified back to the server. They may only be valid for a particular resource or set of resources.
+
+                                      Populated by the system. Read-only. Value must be treated as opaque by clients and . More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                                    type: string
+                                  selfLink:
+                                    description: 'Deprecated: selfLink is a legacy read-only field that is no longer populated by the system.'
+                                    type: string
+                                  uid:
+                                    description: |-
+                                      UID is the unique in time and space value for this object. It is typically generated by the server on successful creation of a resource and is not allowed to change on PUT operations.
+
+                                      Populated by the system. Read-only. More info: http://kubernetes.io/docs/user-guide/identifiers#uids
+                                    type: string
+                                type: object
+                              spec:
+                                description: The specification for the PersistentVolumeClaim. The entire content is copied unchanged into the PVC that gets created from this template. The same fields as in a PersistentVolumeClaim are also valid here.
+                                properties:
+                                  accessModes:
+                                    description: 'accessModes contains the desired access modes the volume should have. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#access-modes-1'
+                                    items:
+                                      type: string
+                                    type: array
+                                  dataSource:
+                                    description: 'dataSource field can be used to specify either: * An existing VolumeSnapshot object (snapshot.storage.k8s.io/VolumeSnapshot) * An existing PVC (PersistentVolumeClaim) If the provisioner or an external controller can support the specified data source, it will create a new volume based on the contents of the specified data source. When the AnyVolumeDataSource feature gate is enabled, dataSource contents will be copied to dataSourceRef, and dataSourceRef contents will be copied to dataSource when dataSourceRef.namespace is not specified. If the namespace is specified, then dataSourceRef will not be copied to dataSource.'
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource being referenced
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  dataSourceRef:
+                                    description: |-
+                                      dataSourceRef specifies the object from which to populate the volume with data, if a non-empty volume is desired. This may be any object from a non-empty API group (non core object) or a PersistentVolumeClaim object. When this field is specified, volume binding will only succeed if the type of the specified object matches some installed volume populator or dynamic provisioner. This field will replace the functionality of the dataSource field and as such if both fields are non-empty, they must have the same value. For backwards compatibility, when namespace isn't specified in dataSourceRef, both fields (dataSource and dataSourceRef) will be set to the same value automatically if one of them is empty and the other is non-empty. When namespace is specified in dataSourceRef, dataSource isn't set to the same value and must be empty. There are three important differences between dataSource and dataSourceRef: * While dataSource only allows two specific types of objects, dataSourceRef
+                                        allows any non-core object, as well as PersistentVolumeClaim objects.
+                                      * While dataSource ignores disallowed values (dropping them), dataSourceRef
+                                        preserves all values, and generates an error if a disallowed value is
+                                        specified.
+                                      * While dataSource only allows local objects, dataSourceRef allows objects
+                                        in any namespaces.
+                                      (Beta) Using this field requires the AnyVolumeDataSource feature gate to be enabled. (Alpha) Using the namespace field of dataSourceRef requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                    properties:
+                                      apiGroup:
+                                        description: APIGroup is the group for the resource being referenced. If APIGroup is not specified, the specified Kind must be in the core API group. For any other third-party types, APIGroup is required.
+                                        type: string
+                                      kind:
+                                        description: Kind is the type of resource being referenced
+                                        type: string
+                                      name:
+                                        description: Name is the name of resource being referenced
+                                        type: string
+                                      namespace:
+                                        description: Namespace is the namespace of resource being referenced Note that when a namespace is specified, a gateway.networking.k8s.io/ReferenceGrant object is required in the referent namespace to allow that namespace's owner to accept the reference. See the ReferenceGrant documentation for details. (Alpha) This field requires the CrossNamespaceVolumeDataSource feature gate to be enabled.
+                                        type: string
+                                    required:
+                                      - kind
+                                      - name
+                                    type: object
+                                  resources:
+                                    description: 'resources represents the minimum resources the volume should have. If RecoverVolumeExpansionFailure feature is enabled users are allowed to specify resource requirements that are lower than previous value but must still be higher than capacity recorded in the status field of the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#resources'
+                                    properties:
+                                      claims:
+                                        description: |-
+                                          Claims lists the names of resources, defined in spec.resourceClaims, that are used by this container.
+
+                                          This is an alpha field and requires enabling the DynamicResourceAllocation feature gate.
+
+                                          This field is immutable.
+                                        items:
+                                          description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                                          properties:
+                                            name:
+                                              description: Name must match the name of one entry in pod.spec.resourceClaims of the Pod where this field is used. It makes that resource available inside a container.
+                                              type: string
+                                          required:
+                                            - name
+                                          type: object
+                                        type: array
+                                      limits:
+                                        additionalProperties:
+                                          description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                          type: string
+                                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                      requests:
+                                        additionalProperties:
+                                          description: "Quantity is a fixed-point representation of a number. It provides convenient marshaling/unmarshaling in JSON and YAML, in addition to String() and AsInt64() accessors.\n\nThe serialization format is:\n\n``` <quantity>        ::= <signedNumber><suffix>\n\n\t(Note that <suffix> may be empty, from the \"\" case in <decimalSI>.)\n\n<digit>           ::= 0 | 1 | ... | 9 <digits>          ::= <digit> | <digit><digits> <number>          ::= <digits> | <digits>.<digits> | <digits>. | .<digits> <sign>            ::= \"+\" | \"-\" <signedNumber>    ::= <number> | <sign><number> <suffix>          ::= <binarySI> | <decimalExponent> | <decimalSI> <binarySI>        ::= Ki | Mi | Gi | Ti | Pi | Ei\n\n\t(International System of units; See: http://physics.nist.gov/cuu/Units/binary.html)\n\n<decimalSI>       ::= m | \"\" | k | M | G | T | P | E\n\n\t(Note that 1024 = 1Ki but 1000 = 1k; I didn't choose the capitalization.)\n\n<decimalExponent> ::= \"e\" <signedNumber> | \"E\" <signedNumber> ```\n\nNo matter which of the three exponent forms is used, no quantity may represent a number greater than 2^63-1 in magnitude, nor may it have more than 3 decimal places. Numbers larger or more precise will be capped or rounded up. (E.g.: 0.1m will rounded up to 1m.) This may be extended in the future if we require larger or smaller quantities.\n\nWhen a Quantity is parsed from a string, it will remember the type of suffix it had, and will use the same type again when it is serialized.\n\nBefore serializing, Quantity will be put in \"canonical form\". This means that Exponent/suffix will be adjusted up or down (with a corresponding increase or decrease in Mantissa) such that:\n\n- No precision is lost - No fractional digits will be emitted - The exponent (or suffix) is as large as possible.\n\nThe sign will be omitted unless the number is negative.\n\nExamples:\n\n- 1.5 will be serialized as \"1500m\" - 1.5Gi will be serialized as \"1536Mi\"\n\nNote that the quantity will NEVER be internally represented by a floating point number. That is the whole point of this exercise.\n\nNon-canonical values will still parse as long as they are well formed, but will be re-emitted in their canonical form. (So always use canonical form, or don't diff.)\n\nThis format is intended to make it difficult to use these numbers without writing some sort of special handling code in the hopes that that will cause implementors to also use a fixed point implementation."
+                                          type: string
+                                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
+                                        type: object
+                                    type: object
+                                  selector:
+                                    description: selector is a label query over volumes to consider for binding.
+                                    properties:
+                                      matchExpressions:
+                                        description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                        items:
+                                          description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                          properties:
+                                            key:
+                                              description: key is the label key that the selector applies to.
+                                              type: string
+                                            operator:
+                                              description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                              type: string
+                                            values:
+                                              description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                              items:
+                                                type: string
+                                              type: array
+                                          required:
+                                            - key
+                                            - operator
+                                          type: object
+                                        type: array
+                                      matchLabels:
+                                        additionalProperties:
+                                          type: string
+                                        description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                        type: object
+                                    type: object
+                                  storageClassName:
+                                    description: 'storageClassName is the name of the StorageClass required by the claim. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#class-1'
+                                    type: string
+                                  volumeMode:
+                                    description: volumeMode defines what type of volume is required by the claim. Value of Filesystem is implied when not included in claim spec.
+                                    type: string
+                                  volumeName:
+                                    description: volumeName is the binding reference to the PersistentVolume backing this claim.
+                                    type: string
+                                type: object
+                            required:
+                              - spec
+                            type: object
+                        type: object
+                      fc:
+                        description: fc represents a Fibre Channel resource that is attached to a kubelet's host machine and then exposed to the pod.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          lun:
+                            description: 'lun is Optional: FC target lun number'
+                            format: int32
+                            type: integer
+                          readOnly:
+                            description: 'readOnly is Optional: Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          targetWWNs:
+                            description: 'targetWWNs is Optional: FC target worldwide names (WWNs)'
+                            items:
+                              type: string
+                            type: array
+                          wwids:
+                            description: 'wwids Optional: FC volume world wide identifiers (wwids) Either wwids or combination of targetWWNs and lun must be set, but not both simultaneously.'
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      flexVolume:
+                        description: flexVolume represents a generic volume resource that is provisioned/attached using an exec based plugin.
+                        properties:
+                          driver:
+                            description: driver is the name of the driver to use for this volume.
+                            type: string
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". The default filesystem depends on FlexVolume script.
+                            type: string
+                          options:
+                            additionalProperties:
+                              type: string
+                            description: 'options is Optional: this field holds extra command options if any.'
+                            type: object
+                          readOnly:
+                            description: 'readOnly is Optional: defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is Optional: secretRef is reference to the secret object containing sensitive information to pass to the plugin scripts. This may be empty if no secret object is specified. If the secret object contains more than one secret, all secrets are passed to the plugin scripts.'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                        required:
+                          - driver
+                        type: object
+                      flocker:
+                        description: flocker represents a Flocker volume attached to a kubelet's host machine. This depends on the Flocker control service being running
+                        properties:
+                          datasetName:
+                            description: datasetName is Name of the dataset stored as metadata -> name on the dataset for Flocker should be considered as deprecated
+                            type: string
+                          datasetUUID:
+                            description: datasetUUID is the UUID of the dataset. This is unique identifier of a Flocker dataset
+                            type: string
+                        type: object
+                      gcePersistentDisk:
+                        description: 'gcePersistentDisk represents a GCE Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                        properties:
+                          fsType:
+                            description: 'fsType is filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          partition:
+                            description: 'partition is the partition in the volume that you want to mount. If omitted, the default is to mount by volume name. Examples: For volume /dev/sda1, you specify the partition as "1". Similarly, the volume partition for /dev/sda is "0" (or you can leave the property empty). More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            format: int32
+                            type: integer
+                          pdName:
+                            description: 'pdName is unique name of the PD resource in GCE. Used to identify the disk in GCE. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#gcepersistentdisk'
+                            type: boolean
+                        required:
+                          - pdName
+                        type: object
+                      gitRepo:
+                        description: 'gitRepo represents a git repository at a particular revision. DEPRECATED: GitRepo is deprecated. To provision a container with a git repo, mount an EmptyDir into an InitContainer that clones the repo using git, then mount the EmptyDir into the Pod''s container.'
+                        properties:
+                          directory:
+                            description: directory is the target directory name. Must not contain or start with '..'.  If '.' is supplied, the volume directory will be the git repository.  Otherwise, if specified, the volume will contain the git repository in the subdirectory with the given name.
+                            type: string
+                          repository:
+                            description: repository is the URL
+                            type: string
+                          revision:
+                            description: revision is the commit hash for the specified revision.
+                            type: string
+                        required:
+                          - repository
+                        type: object
+                      glusterfs:
+                        description: 'glusterfs represents a Glusterfs mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/glusterfs/README.md'
+                        properties:
+                          endpoints:
+                            description: 'endpoints is the endpoint name that details Glusterfs topology. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          path:
+                            description: 'path is the Glusterfs volume path. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the Glusterfs volume to be mounted with read-only permissions. Defaults to false. More info: https://examples.k8s.io/volumes/glusterfs/README.md#create-a-pod'
+                            type: boolean
+                        required:
+                          - endpoints
+                          - path
+                        type: object
+                      hostPath:
+                        description: 'hostPath represents a pre-existing file or directory on the host machine that is directly exposed to the container. This is generally used for system agents or other privileged things that are allowed to see the host machine. Most containers will NOT need this. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                        properties:
+                          path:
+                            description: 'path of the directory on the host. If the path is a symlink, it will follow the link to the real path. More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                          type:
+                            description: 'type for HostPath Volume Defaults to "" More info: https://kubernetes.io/docs/concepts/storage/volumes#hostpath'
+                            type: string
+                        required:
+                          - path
+                        type: object
+                      iscsi:
+                        description: 'iscsi represents an ISCSI Disk resource that is attached to a kubelet''s host machine and then exposed to the pod. More info: https://examples.k8s.io/volumes/iscsi/README.md'
+                        properties:
+                          chapAuthDiscovery:
+                            description: chapAuthDiscovery defines whether support iSCSI Discovery CHAP authentication
+                            type: boolean
+                          chapAuthSession:
+                            description: chapAuthSession defines whether support iSCSI Session CHAP authentication
+                            type: boolean
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#iscsi'
+                            type: string
+                          initiatorName:
+                            description: initiatorName is the custom iSCSI Initiator Name. If initiatorName is specified with iscsiInterface simultaneously, new iSCSI interface <target portal>:<volume name> will be created for the connection.
+                            type: string
+                          iqn:
+                            description: iqn is the target iSCSI Qualified Name.
+                            type: string
+                          iscsiInterface:
+                            description: iscsiInterface is the interface Name that uses an iSCSI transport. Defaults to 'default' (tcp).
+                            type: string
+                          lun:
+                            description: lun represents iSCSI Target Lun number.
+                            format: int32
+                            type: integer
+                          portals:
+                            description: portals is the iSCSI Target Portal List. The portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                            items:
+                              type: string
+                            type: array
+                          readOnly:
+                            description: readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false.
+                            type: boolean
+                          secretRef:
+                            description: secretRef is the CHAP Secret for iSCSI target and initiator authentication
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          targetPortal:
+                            description: targetPortal is iSCSI Target Portal. The Portal is either an IP or ip_addr:port if the port is other than default (typically TCP ports 860 and 3260).
+                            type: string
+                        required:
+                          - iqn
+                          - lun
+                          - targetPortal
+                        type: object
+                      name:
+                        description: 'name of the volume. Must be a DNS_LABEL and unique within the pod. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                        type: string
+                      nfs:
+                        description: 'nfs represents an NFS mount on the host that shares a pod''s lifetime More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                        properties:
+                          path:
+                            description: 'path that is exported by the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the NFS export to be mounted with read-only permissions. Defaults to false. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: boolean
+                          server:
+                            description: 'server is the hostname or IP address of the NFS server. More info: https://kubernetes.io/docs/concepts/storage/volumes#nfs'
+                            type: string
+                        required:
+                          - path
+                          - server
+                        type: object
+                      persistentVolumeClaim:
+                        description: 'persistentVolumeClaimVolumeSource represents a reference to a PersistentVolumeClaim in the same namespace. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                        properties:
+                          claimName:
+                            description: 'claimName is the name of a PersistentVolumeClaim in the same namespace as the pod using this volume. More info: https://kubernetes.io/docs/concepts/storage/persistent-volumes#persistentvolumeclaims'
+                            type: string
+                          readOnly:
+                            description: readOnly Will force the ReadOnly setting in VolumeMounts. Default false.
+                            type: boolean
+                        required:
+                          - claimName
+                        type: object
+                      photonPersistentDisk:
+                        description: photonPersistentDisk represents a PhotonController persistent disk attached and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          pdID:
+                            description: pdID is the ID that identifies Photon Controller persistent disk
+                            type: string
+                        required:
+                          - pdID
+                        type: object
+                      portworxVolume:
+                        description: portworxVolume represents a portworx volume attached and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fSType represents the filesystem type to mount Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          volumeID:
+                            description: volumeID uniquely identifies a Portworx volume
+                            type: string
+                        required:
+                          - volumeID
+                        type: object
+                      projected:
+                        description: projected items for all in one resources secrets, configmaps, and downward API
+                        properties:
+                          defaultMode:
+                            description: defaultMode are the mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.
+                            format: int32
+                            type: integer
+                          sources:
+                            description: sources is the list of volume projections
+                            items:
+                              description: Projection that may be projected along with other supported volume types
+                              properties:
+                                configMap:
+                                  description: configMap information about the configMap data to project
+                                  properties:
+                                    items:
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced ConfigMap will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the ConfigMap, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: optional specify whether the ConfigMap or its keys must be defined
+                                      type: boolean
+                                  type: object
+                                downwardAPI:
+                                  description: downwardAPI information about the downwardAPI data to project
+                                  properties:
+                                    items:
+                                      description: Items is a list of DownwardAPIVolume file
+                                      items:
+                                        description: DownwardAPIVolumeFile represents information to create the file containing the pod field
+                                        properties:
+                                          fieldRef:
+                                            description: 'Required: Selects a field of the pod: only annotations, labels, name and namespace are supported.'
+                                            properties:
+                                              apiVersion:
+                                                description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                                type: string
+                                              fieldPath:
+                                                description: Path of the field to select in the specified API version.
+                                                type: string
+                                            required:
+                                              - fieldPath
+                                            type: object
+                                          mode:
+                                            description: 'Optional: mode bits used to set permissions on this file, must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: 'Required: Path is  the relative path name of the file to be created. Must not be absolute or contain the ''..'' path. Must be utf-8 encoded. The first item of the relative path must not start with ''..'''
+                                            type: string
+                                          resourceFieldRef:
+                                            description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, requests.cpu and requests.memory) are currently supported.'
+                                            properties:
+                                              containerName:
+                                                description: 'Container name: required for volumes, optional for env vars'
+                                                type: string
+                                              divisor:
+                                                description: Specifies the output format of the exposed resources, defaults to "1"
+                                                type: string
+                                              resource:
+                                                description: 'Required: resource to select'
+                                                type: string
+                                            required:
+                                              - resource
+                                            type: object
+                                        required:
+                                          - path
+                                        type: object
+                                      type: array
+                                  type: object
+                                secret:
+                                  description: secret information about the secret data to project
+                                  properties:
+                                    items:
+                                      description: items if unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                                      items:
+                                        description: Maps a string key to a path within a volume.
+                                        properties:
+                                          key:
+                                            description: key is the key to project.
+                                            type: string
+                                          mode:
+                                            description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                            format: int32
+                                            type: integer
+                                          path:
+                                            description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                            type: string
+                                        required:
+                                          - key
+                                          - path
+                                        type: object
+                                      type: array
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                    optional:
+                                      description: optional field specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  type: object
+                                serviceAccountToken:
+                                  description: serviceAccountToken is information about the serviceAccountToken data to project
+                                  properties:
+                                    audience:
+                                      description: audience is the intended audience of the token. A recipient of a token must identify itself with an identifier specified in the audience of the token, and otherwise should reject the token. The audience defaults to the identifier of the apiserver.
+                                      type: string
+                                    expirationSeconds:
+                                      description: expirationSeconds is the requested duration of validity of the service account token. As the token approaches expiration, the kubelet volume plugin will proactively rotate the service account token. The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.Defaults to 1 hour and must be at least 10 minutes.
+                                      format: int64
+                                      type: integer
+                                    path:
+                                      description: path is the path relative to the mount point of the file to project the token into.
+                                      type: string
+                                  required:
+                                    - path
+                                  type: object
+                              type: object
+                            type: array
+                        type: object
+                      quobyte:
+                        description: quobyte represents a Quobyte mount on the host that shares a pod's lifetime
+                        properties:
+                          group:
+                            description: group to map volume access to Default is no group
+                            type: string
+                          readOnly:
+                            description: readOnly here will force the Quobyte volume to be mounted with read-only permissions. Defaults to false.
+                            type: boolean
+                          registry:
+                            description: registry represents a single or multiple Quobyte Registry services specified as a string as host:port pair (multiple entries are separated with commas) which acts as the central registry for volumes
+                            type: string
+                          tenant:
+                            description: tenant owning the given Quobyte volume in the Backend Used with dynamically provisioned Quobyte volumes, value is set by the plugin
+                            type: string
+                          user:
+                            description: user to map volume access to Defaults to serivceaccount user
+                            type: string
+                          volume:
+                            description: volume is a string that references an already created Quobyte volume by name.
+                            type: string
+                        required:
+                          - registry
+                          - volume
+                        type: object
+                      rbd:
+                        description: 'rbd represents a Rados Block Device mount on the host that shares a pod''s lifetime. More info: https://examples.k8s.io/volumes/rbd/README.md'
+                        properties:
+                          fsType:
+                            description: 'fsType is the filesystem type of the volume that you want to mount. Tip: Ensure that the filesystem type is supported by the host operating system. Examples: "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified. More info: https://kubernetes.io/docs/concepts/storage/volumes#rbd'
+                            type: string
+                          image:
+                            description: 'image is the rados image name. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          keyring:
+                            description: 'keyring is the path to key ring for RBDUser. Default is /etc/ceph/keyring. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          monitors:
+                            description: 'monitors is a collection of Ceph monitors. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            items:
+                              type: string
+                            type: array
+                          pool:
+                            description: 'pool is the rados pool name. Default is rbd. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                          readOnly:
+                            description: 'readOnly here will force the ReadOnly setting in VolumeMounts. Defaults to false. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: boolean
+                          secretRef:
+                            description: 'secretRef is name of the authentication secret for RBDUser. If provided overrides keyring. Default is nil. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          user:
+                            description: 'user is the rados user name. Default is admin. More info: https://examples.k8s.io/volumes/rbd/README.md#how-to-use-it'
+                            type: string
+                        required:
+                          - image
+                          - monitors
+                        type: object
+                      scaleIO:
+                        description: scaleIO represents a ScaleIO persistent volume attached and mounted on Kubernetes nodes.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Default is "xfs".
+                            type: string
+                          gateway:
+                            description: gateway is the host address of the ScaleIO API Gateway.
+                            type: string
+                          protectionDomain:
+                            description: protectionDomain is the name of the ScaleIO Protection Domain for the configured storage.
+                            type: string
+                          readOnly:
+                            description: readOnly Defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: secretRef references to the secret for ScaleIO user and other sensitive information. If this is not provided, Login operation will fail.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          sslEnabled:
+                            description: sslEnabled Flag enable/disable SSL communication with Gateway, default false
+                            type: boolean
+                          storageMode:
+                            description: storageMode indicates whether the storage for a volume should be ThickProvisioned or ThinProvisioned. Default is ThinProvisioned.
+                            type: string
+                          storagePool:
+                            description: storagePool is the ScaleIO Storage Pool associated with the protection domain.
+                            type: string
+                          system:
+                            description: system is the name of the storage system as configured in ScaleIO.
+                            type: string
+                          volumeName:
+                            description: volumeName is the name of a volume already created in the ScaleIO system that is associated with this volume source.
+                            type: string
+                        required:
+                          - gateway
+                          - secretRef
+                          - system
+                        type: object
+                      secret:
+                        description: 'secret represents a secret that should populate this volume. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                        properties:
+                          defaultMode:
+                            description: 'defaultMode is Optional: mode bits used to set permissions on created files by default. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. Defaults to 0644. Directories within the path are not affected by this setting. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                            format: int32
+                            type: integer
+                          items:
+                            description: items If unspecified, each key-value pair in the Data field of the referenced Secret will be projected into the volume as a file whose name is the key and content is the value. If specified, the listed keys will be projected into the specified paths, and unlisted keys will not be present. If a key is specified which is not present in the Secret, the volume setup will error unless it is marked optional. Paths must be relative and may not contain the '..' path or start with '..'.
+                            items:
+                              description: Maps a string key to a path within a volume.
+                              properties:
+                                key:
+                                  description: key is the key to project.
+                                  type: string
+                                mode:
+                                  description: 'mode is Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                  format: int32
+                                  type: integer
+                                path:
+                                  description: path is the relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                  type: string
+                              required:
+                                - key
+                                - path
+                              type: object
+                            type: array
+                          optional:
+                            description: optional field specify whether the Secret or its keys must be defined
+                            type: boolean
+                          secretName:
+                            description: 'secretName is the name of the secret in the pod''s namespace to use. More info: https://kubernetes.io/docs/concepts/storage/volumes#secret'
+                            type: string
+                        type: object
+                      storageos:
+                        description: storageOS represents a StorageOS volume attached and mounted on Kubernetes nodes.
+                        properties:
+                          fsType:
+                            description: fsType is the filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          readOnly:
+                            description: readOnly defaults to false (read/write). ReadOnly here will force the ReadOnly setting in VolumeMounts.
+                            type: boolean
+                          secretRef:
+                            description: secretRef specifies the secret to use for obtaining the StorageOS API credentials.  If not specified, default values will be attempted.
+                            properties:
+                              name:
+                                description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                type: string
+                            type: object
+                          volumeName:
+                            description: volumeName is the human-readable name of the StorageOS volume.  Volume names are only unique within a namespace.
+                            type: string
+                          volumeNamespace:
+                            description: volumeNamespace specifies the scope of the volume within StorageOS.  If no namespace is specified then the Pod's namespace will be used.  This allows the Kubernetes name scoping to be mirrored within StorageOS for tighter integration. Set VolumeName to any name to override the default behaviour. Set to "default" if you are not using namespaces within StorageOS. Namespaces that do not pre-exist within StorageOS will be created.
+                            type: string
+                        type: object
+                      vsphereVolume:
+                        description: vsphereVolume represents a vSphere volume attached and mounted on kubelets host machine
+                        properties:
+                          fsType:
+                            description: fsType is filesystem type to mount. Must be a filesystem type supported by the host operating system. Ex. "ext4", "xfs", "ntfs". Implicitly inferred to be "ext4" if unspecified.
+                            type: string
+                          storagePolicyID:
+                            description: storagePolicyID is the storage Policy Based Management (SPBM) profile ID associated with the StoragePolicyName.
+                            type: string
+                          storagePolicyName:
+                            description: storagePolicyName is the storage Policy Based Management (SPBM) profile name.
+                            type: string
+                          volumePath:
+                            description: volumePath is the path that identifies vSphere volume vmdk
+                            type: string
+                        required:
+                          - volumePath
+                        type: object
+                    required:
+                      - name
+                    type: object
+                  type: array
                 historicals:
                   description: Configuration of the historical role
                   properties:

--- a/deploy/helm/druid-operator/crds/crds.yaml
+++ b/deploy/helm/druid-operator/crds/crds.yaml
@@ -1475,7 +1475,7 @@ spec:
                           type: object
                       type: object
                     extraVolumes:
-                      description: Extra volumes to mount into every container, this can be useful to for example make client certificates, keytabs or similar things available to processors These volumes will be mounted into all pods
+                      description: Extra volumes to mount into every container, this can be useful to for example make client certificates, keytabs or similar things available to processors These volumes will be mounted into all pods below `/stackable/userdata/{volumename}`
                       items:
                         description: Volume represents a named volume in a pod that may be accessed by any container in the pod.
                         properties:

--- a/docs/modules/druid/pages/usage.adoc
+++ b/docs/modules/druid/pages/usage.adoc
@@ -583,7 +583,7 @@ Since Druid actively runs ingestion tasks there may be a need to make extra file
 
 These could for example be client certificates used to connect to a Kafka cluster, a keytab to obtain a Kerberos ticket, or similar things.
 
-In order to make these files available the operator allows specifying extra volumes that will be added to the MiddleManager pods deployed for this cluster.
+In order to make these files available the operator allows specifying extra volumes that will be added to all pods deployed for this cluster.
 
 [source,yaml]
 ----

--- a/docs/modules/druid/pages/usage.adoc
+++ b/docs/modules/druid/pages/usage.adoc
@@ -577,7 +577,7 @@ To address this, some affinities will be created to attract these roles:
 - No affinities
 
 
-=== Adding External Files to MiddleManagers for Ingestion
+=== Adding external files, e.g. for ingestion
 
 Since Druid actively runs ingestion tasks there may be a need to make extra files available to the processes.
 

--- a/docs/modules/druid/pages/usage.adoc
+++ b/docs/modules/druid/pages/usage.adoc
@@ -589,10 +589,10 @@ In order to make these files available the operator allows specifying extra volu
 ----
 spec:
   clusterConfig:
-      extraVolumes:
-      - configMap:
-          name: druid-client-certs
-        name: certs
+    extraVolumes:
+      - name: google-service-account
+        secret:
+          secretName: google-service-account
 ----
 
 All `Volumes` specified in this section will be made available under `/stackable/userdata/{volumename}`.

--- a/docs/modules/druid/pages/usage.adoc
+++ b/docs/modules/druid/pages/usage.adoc
@@ -575,3 +575,23 @@ To address this, some affinities will be created to attract these roles:
 *For coordinators:*
 
 - No affinities
+
+
+=== Adding External Files to MiddleManagers for Ingestion
+
+Since Druid actively runs ingestion tasks there may be a need to make extra files available to the processes.
+
+These could for example be client certificates used to connect to a Kafka cluster, a keytab to obtain a Kerberos ticket, or similar things.
+
+In order to make these files available the operator allows specifying extra volumes that will be added to the MiddleManager pods deployed for this cluster.
+
+[source,yaml]
+----
+spec:
+  extraVolumes:
+  - configMap:
+      name: druid-client-certs
+    name: certs
+----
+
+All `Volumes` specified in this section will be made available under `/stackable/userdata/{volumename}`.

--- a/docs/modules/druid/pages/usage.adoc
+++ b/docs/modules/druid/pages/usage.adoc
@@ -588,10 +588,11 @@ In order to make these files available the operator allows specifying extra volu
 [source,yaml]
 ----
 spec:
-  extraVolumes:
-  - configMap:
-      name: druid-client-certs
-    name: certs
+  clusterConfig:
+      extraVolumes:
+      - configMap:
+          name: druid-client-certs
+        name: certs
 ----
 
 All `Volumes` specified in this section will be made available under `/stackable/userdata/{volumename}`.

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -38,6 +38,7 @@ use stackable_operator::{
     schemars::{self, JsonSchema},
 };
 use std::collections::{BTreeMap, HashMap};
+use stackable_operator::k8s_openapi::api::core::v1::Volume;
 use strum::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 use tls::default_druid_tls;
 
@@ -180,6 +181,12 @@ pub struct DruidClusterSpec {
     pub routers: Role<RouterConfigFragment>,
     /// Common cluster wide configuration that can not differ or be overridden on a role or role group level
     pub cluster_config: DruidClusterConfig,
+    /// Extra volumes to mount into every container, this can be useful to for example make client
+    /// certificates, keytabs or similar things available to processors
+    /// These volumes will be mounted into the MiddleManager pods, as these are the ones actually
+    /// running ingestion tasks, for which this will be needed
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_volumes: Vec<Volume>,
 }
 
 #[derive(

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -15,6 +15,7 @@ use authorization::DruidAuthorization;
 use resource::RoleResource;
 use serde::{Deserialize, Serialize};
 use snafu::{OptionExt, ResultExt, Snafu};
+use stackable_operator::k8s_openapi::api::core::v1::Volume;
 use stackable_operator::{
     client::Client,
     commons::{
@@ -38,7 +39,6 @@ use stackable_operator::{
     schemars::{self, JsonSchema},
 };
 use std::collections::{BTreeMap, HashMap};
-use stackable_operator::k8s_openapi::api::core::v1::Volume;
 use strum::{Display, EnumDiscriminants, EnumIter, EnumString, IntoStaticStr};
 use tls::default_druid_tls;
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -181,11 +181,6 @@ pub struct DruidClusterSpec {
     pub routers: Role<RouterConfigFragment>,
     /// Common cluster wide configuration that can not differ or be overridden on a role or role group level
     pub cluster_config: DruidClusterConfig,
-    /// Extra volumes to mount into every container, this can be useful to for example make client
-    /// certificates, keytabs or similar things available to processors
-    /// These volumes will be mounted into all pods
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub extra_volumes: Vec<Volume>,
 }
 
 #[derive(
@@ -236,6 +231,11 @@ pub struct DruidClusterConfig {
     /// It must contain the key `ADDRESS` with the address of the Vector aggregator.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vector_aggregator_config_map_name: Option<String>,
+    /// Extra volumes to mount into every container, this can be useful to for example make client
+    /// certificates, keytabs or similar things available to processors
+    /// These volumes will be mounted into all pods
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extra_volumes: Vec<Volume>,
 }
 
 /// Common configuration for all role groups

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -183,8 +183,7 @@ pub struct DruidClusterSpec {
     pub cluster_config: DruidClusterConfig,
     /// Extra volumes to mount into every container, this can be useful to for example make client
     /// certificates, keytabs or similar things available to processors
-    /// These volumes will be mounted into the MiddleManager pods, as these are the ones actually
-    /// running ingestion tasks, for which this will be needed
+    /// These volumes will be mounted into all pods
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_volumes: Vec<Volume>,
 }

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -233,7 +233,7 @@ pub struct DruidClusterConfig {
     pub vector_aggregator_config_map_name: Option<String>,
     /// Extra volumes to mount into every container, this can be useful to for example make client
     /// certificates, keytabs or similar things available to processors
-    /// These volumes will be mounted into all pods
+    /// These volumes will be mounted into all pods below `/stackable/userdata/{volumename}`
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub extra_volumes: Vec<Volume>,
 }

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -797,22 +797,20 @@ fn build_rolegroup_statefulset(
     // Known roles are MiddleManagers for ingestion and Historicals for deep storage (GCS plugin)
     // We may at some time in the future revisit this and limit it again to avoid needlessly
     // propagating potentially confidential files throughout the cluster
-    if !druid.spec.extra_volumes.is_empty() {
-        for volume in &druid.spec.extra_volumes {
-            // Extract values into vars so we make it impossible to log something other than
-            // what we actually use to create the mounts - maybe paranoid, but hey ..
-            let volume_name = &volume.name;
-            let mount_point = format!("{USERDATA_MOUNTPOINT}/{}", volume.name);
+    for volume in &druid.spec.cluster_config.extra_volumes {
+        // Extract values into vars so we make it impossible to log something other than
+        // what we actually use to create the mounts - maybe paranoid, but hey ..
+        let volume_name = &volume.name;
+        let mount_point = format!("{USERDATA_MOUNTPOINT}/{}", volume.name);
 
-            tracing::info!(
-                ?volume_name,
-                ?mount_point,
-                ?role,
-                "Adding user specified extra volume",
-            );
-            pb.add_volume(volume.clone());
-            cb_druid.add_volume_mount(volume_name, mount_point);
-        }
+        tracing::info!(
+            ?volume_name,
+            ?mount_point,
+            ?role,
+            "Adding user specified extra volume",
+        );
+        pb.add_volume(volume.clone());
+        cb_druid.add_volume_mount(volume_name, mount_point);
     }
 
     pb.image_pull_secrets_from_product_image(resolved_product_image)

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -23,6 +23,7 @@ use stackable_druid_crd::{
     S3_PATH_STYLE_ACCESS, S3_SECRET_DIR_NAME, ZOOKEEPER_CONNECTION_STRING,
 };
 use stackable_druid_crd::{build_recommended_labels, Container, ENV_INTERNAL_SECRET};
+use stackable_operator::k8s_openapi::api::core::v1::VolumeMount;
 use stackable_operator::{
     builder::{
         ConfigMapBuilder, ContainerBuilder, ObjectMetaBuilder, PodBuilder,
@@ -66,7 +67,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use stackable_operator::k8s_openapi::api::core::v1::VolumeMount;
 use strum::{EnumDiscriminants, IntoStaticStr};
 
 pub const CONTROLLER_NAME: &str = "druidcluster";

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -794,9 +794,11 @@ fn build_rolegroup_statefulset(
     // Add extra mounts if any are specified and the current role is MiddleManager
     // Extra mounts may be needed for ingestion to add required certificates, truststores or similar
     // files.
-    // Since ingestion tasks only run on MiddleManagers it is enough to add these in that case
-    // and not needlessly propagate those files to more pods than needed
-    if role == DruidRole::MiddleManager && !druid.spec.extra_volumes.is_empty() {
+    // Mounts are added to all roles, as we are currently unsure where they may be needed
+    // Known roles are MiddleManagers for ingestion and Historicals for deep storage (GCS plugin)
+    // We may at some time in the future revisit this and limit it again to avoid needlessly
+    // propagating potentially confidential files throughout the cluster
+    if !druid.spec.extra_volumes.is_empty() {
         let extra_volumes = &druid.spec.extra_volumes;
         let volume_names: Vec<String> = extra_volumes
             .clone()


### PR DESCRIPTION
# Description
Druid can run ingestions tasks and sometimes it is necessary to supply files for configuring these tasks, like certificates or keytabs..

This PR allows specifying extra volumes that will be added to middlemanager pods as mounts, so that these files can be used when configuring Druid ingestion.

It has been closely modelled (read that as copied and pasted) from https://github.com/stackabletech/nifi-operator/pull/434

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
