### PR TITLE
POC of reconciliation pause functionality

### DIFF
--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -181,6 +181,16 @@ pub struct DruidClusterSpec {
     pub routers: Role<RouterConfigFragment>,
     /// Common cluster wide configuration that can not differ or be overridden on a role or role group level
     pub cluster_config: DruidClusterConfig,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cluster_operations: Option<ClusterOperations>,
+}
+
+// TODO: move this to operator-rs
+#[derive(Clone, Debug, Deserialize, JsonSchema, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ClusterOperations {
+    #[serde(default)]
+    pub reconciliation_paused: bool,
 }
 
 #[derive(

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -180,9 +180,8 @@ pub struct DruidClusterSpec {
     /// Configuration of the router role
     pub routers: Role<RouterConfigFragment>,
     /// Common cluster wide configuration that can not differ or be overridden on a role or role group level
-    pub cluster_config: DruidClusterConfig,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub cluster_operations: Option<ClusterOperations>,
+    pub cluster_config: DruidClusterConfig, 
+    pub cluster_operations: ClusterOperations,
 }
 
 // TODO: move this to operator-rs
@@ -190,7 +189,7 @@ pub struct DruidClusterSpec {
 #[serde(rename_all = "camelCase")]
 pub struct ClusterOperations {
     #[serde(default)]
-    pub reconciliation_paused: bool,
+    pub reconciliation_paused: Option<bool>,
 }
 
 #[derive(

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -1,4 +1,4 @@
-//! Ensures that `Pod`s are configured and running for each [`DruidCluster`]
+ //! Ensures that `Pod`s are configured and running for each [`DruidCluster`]
 use crate::{
     config::get_jvm_config,
     discovery::{self, build_discovery_configmaps},
@@ -232,9 +232,9 @@ impl ReconcilerError for Error {
 }
 
 // TODO: move this to operator-rs
-fn handle_pause_reconcile_flag(cluster_operations: &Option<ClusterOperations>) -> Option<Action> {
-    if let Some(ops) = &cluster_operations {
-        if ops.reconciliation_paused {
+fn handle_pause_reconcile_flag(cluster_operations: &ClusterOperations) -> Option<Action> {
+    if let Some(recon_paused) = cluster_operations.reconciliation_paused{
+        if recon_paused {
             tracing::info!(
                 "Reconciliation is paused, due to ops flag. Ending reconcile without changes"
             );
@@ -244,6 +244,9 @@ fn handle_pause_reconcile_flag(cluster_operations: &Option<ClusterOperations>) -
 
     None
 }
+
+// TODO - MW: Have a stop function
+
 
 pub async fn reconcile_druid(druid: Arc<DruidCluster>, ctx: Arc<Ctx>) -> Result<Action> {
     tracing::info!("Starting reconcile");
@@ -1172,3 +1175,4 @@ mod test {
         Ok(())
     }
 }
+

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -247,6 +247,11 @@ fn handle_pause_reconcile_flag(cluster_operations: &Option<ClusterOperations>) -
 
 pub async fn reconcile_druid(druid: Arc<DruidCluster>, ctx: Arc<Ctx>) -> Result<Action> {
     tracing::info!("Starting reconcile");
+
+    if let Some(action) = handle_pause_reconcile_flag(&druid.spec.cluster_operations) {
+        return Ok(action);
+    }
+
     let client = &ctx.client;
     let namespace = &druid
         .metadata

--- a/tests/templates/kuttl/pause/02-assert.yaml
+++ b/tests/templates/kuttl/pause/02-assert.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 300
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-zk-server-default
+status:
+  readyReplicas: 1
+  replicas: 1
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hdfs-znode

--- a/tests/templates/kuttl/pause/02-install-zk.yaml.j2
+++ b/tests/templates/kuttl/pause/02-install-zk.yaml.j2
@@ -1,0 +1,37 @@
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperCluster
+metadata:
+  name: druid-zk
+spec:
+  image:
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['zookeeper-latest'].split('-stackable')[1] }}"
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+  clusterConfig:
+    logging:
+      vectorAggregatorConfigMapName: vector-aggregator-discovery
+{% endif %}
+  servers:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    roleGroups:
+      default:
+        replicas: 1
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperZnode
+metadata:
+  name: druid-znode
+spec:
+  clusterRef:
+    name: druid-zk
+---
+apiVersion: zookeeper.stackable.tech/v1alpha1
+kind: ZookeeperZnode
+metadata:
+  name: hdfs-znode
+spec:
+  clusterRef:
+    name: druid-zk

--- a/tests/templates/kuttl/pause/04-assert.yaml
+++ b/tests/templates/kuttl/pause/04-assert.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 15
+# wait repeatedly, to make sure the operator had a chance to react
+commands:
+  - script: sleep 5

--- a/tests/templates/kuttl/pause/04-errors.yaml
+++ b/tests/templates/kuttl/pause/04-errors.yaml
@@ -1,0 +1,29 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 60
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-broker-default
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-coordinator-default
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-historical-default
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-middlemanager-default
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: druid-router-default

--- a/tests/templates/kuttl/pause/04-errors.yaml
+++ b/tests/templates/kuttl/pause/04-errors.yaml
@@ -1,8 +1,4 @@
 ---
-apiVersion: kuttl.dev/v1beta1
-kind: TestAssert
-timeout: 60
----
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/templates/kuttl/pause/04-install-druid.yaml.j2
+++ b/tests/templates/kuttl/pause/04-install-druid.yaml.j2
@@ -1,0 +1,68 @@
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: install-druid
+timeout: 60
+---
+apiVersion: druid.stackable.tech/v1alpha1
+kind: DruidCluster
+metadata:
+  name: druid
+spec:
+  image:
+    productVersion: "{{ test_scenario['values']['druid-latest'].split('-stackable')[0] }}"
+    stackableVersion: "{{ test_scenario['values']['druid-latest'].split('-stackable')[1] }}"
+  clusterOperations:
+    reconciliationPaused: true
+  clusterConfig:
+    deepStorage:
+      hdfs:
+        configMapName: druid-hdfs
+        directory: /druid
+    metadataStorageDatabase:
+      dbType: postgresql
+      connString: jdbc:postgresql://druid-postgresql/druid
+      host: druid-postgresql
+      port: 5432
+      user: druid
+      password: druid
+{% if lookup('env', 'VECTOR_AGGREGATOR') %}
+    vectorAggregatorConfigMapName: vector-aggregator-discovery
+{% endif %}
+    zookeeperConfigMapName: druid-znode
+  brokers:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    roleGroups:
+      default:
+        replicas: 1
+  coordinators:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    roleGroups:
+      default:
+        replicas: 1
+  historicals:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    roleGroups:
+      default:
+        replicas: 1
+  middleManagers:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    roleGroups:
+      default:
+        replicas: 1
+  routers:
+    config:
+      logging:
+        enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
+    roleGroups:
+      default:
+        replicas: 1

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -46,6 +46,9 @@ tests:
       - druid
       - zookeeper
       - hadoop
+  - name: pause
+    dimensions:
+      - druid-latest
   - name: authorizer
     dimensions:
       - druid

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -49,6 +49,8 @@ tests:
   - name: pause
     dimensions:
       - druid-latest
+      - zookeeper-latest
+      - hadoop-latest
   - name: authorizer
     dimensions:
       - druid


### PR DESCRIPTION
# Description

Closes https://github.com/stackabletech/druid-operator/issues/418

This code will not be merged, but will inform future progress in the epic.

It proposes:

* A kuttl-driven smoke test for the pause functionality
* A reusable CRD snippet
* A callable helper function to handle the pause field

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
