### PR TITLE
Add missing crd defaults to 23.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [23.4.1] - 2023-05-17
+
+### Added
+
+- Missing CRD defaults for `status.conditions` field ([#439]).
+
+[#439]: https://github.com/stackabletech/druid-operator/pull/439
+
 ## [23.4.0] - 2023-04-17
 
 ### Added

--- a/deploy/helm/druid-operator/crds/crds.yaml
+++ b/deploy/helm/druid-operator/crds/crds.yaml
@@ -7931,6 +7931,7 @@ spec:
               nullable: true
               properties:
                 conditions:
+                  default: []
                   items:
                     properties:
                       lastTransitionTime:
@@ -7972,8 +7973,6 @@ spec:
                       - type
                     type: object
                   type: array
-              required:
-                - conditions
               type: object
           required:
             - spec

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -1237,6 +1237,7 @@ impl Configuration for CoordinatorConfigFragment {
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct DruidClusterStatus {
+    #[serde(default)]
     pub conditions: Vec<ClusterCondition>,
 }
 


### PR DESCRIPTION
# Description

Add missing crd defaults (#439)

cherry picked from commit 2a1ed255ea4009f07d7892dfdf17041ddde612f6

<!-- Commit message above. Everything below is not added to the message. Do not change this line! -->

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
```

Once the review is done, comment `bors r+` (or `bors merge`) to merge. [Further information](https://bors.tech/documentation/getting-started/#reviewing-pull-requests)
