### PR TITLE
[Merged by Bors] - nightly test suite

### DIFF
--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -123,17 +123,33 @@ tests:
       - hadoop-latest
       - druid-latest
 suites:
-  - name: latest
+  - name: nightly
+    patch:
+      - dimensions:
+          - name: druid
+            expr: last
+          - name: zookeeper
+            expr: last
+          - name: hadoop
+            expr: last
+          - name: s3-use-tls
+            expr: "true"
+          - name: ldap-use-tls
+            expr: "true"
+  - name: smoke-latest
+    select:
+      - smoke
     patch:
       - dimensions:
           - expr: last
-  - name: smoke
-    select:
-      - smoke
   - name: openshift
     patch:
       - dimensions:
           - expr: last
       - dimensions:
           - name: openshift
+            expr: "true"
+          - name: s3-use-tls
+            expr: "true"
+          - name: ldap-use-tls
             expr: "true"


### PR DESCRIPTION
Part of https://github.com/stackabletech/ci/issues/62

```
(stackable) ➜  druid-operator git:(main) ✗ beku -s nightly                                                                                                                                                                        
INFO:root:Expanding test case id [smoke_druid-26.0.0-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev_openshift-false]           
INFO:root:Expanding test case id [authorizer_druid-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_opa-0.45.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]      
INFO:root:Expanding test case id [ingestion-no-s3-ext_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]                                                           
INFO:root:Expanding test case id [ingestion-s3-ext_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]                                                              
INFO:root:Expanding test case id [s3-deep-storage_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_s3-use-tls-true]                                                                               INFO:root:Expanding test case id [hdfs-deep-storage_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]       
INFO:root:Expanding test case id [resources_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]                                                                                                     INFO:root:Expanding test case id [orphaned-resources_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]
INFO:root:Expanding test case id [tls_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_tls-mode-no-tls_openshift-false]                                                                           INFO:root:Expanding test case id [tls_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_tls-mode-internal-and-server-tls_openshift-false]
INFO:root:Expanding test case id [tls_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_tls-mode-internal-and-server-tls-and-tls-client-auth_openshift-false]                                      INFO:root:Expanding test case id [ldap-authentication_druid-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_opa-0.45.0-stackable0.0.0-dev_hadoop-latest-3.3.4-stackable0.0.0-dev_ldap-use-tls-true_ldap-no-bin
d-credentials-false_openshift-false]                                                                                                                                                                                              INFO:root:Expanding test case id [logging_druid-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]
INFO:root:Expanding test case id [cluster-operation_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-latest-3.3.4-stackable0.0.0-dev]                           
```
```
(stackable) ➜  druid-operator git:(main) ✗ beku -s smoke-latest                                                                                                                                                                   
INFO:root:Expanding test case id [smoke_druid-26.0.0-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev_openshift-false]
```
```
(stackable) ➜  druid-operator git:(main) ✗ beku -s openshift                                                                                                                                                                      
INFO:root:Expanding test case id [smoke_druid-26.0.0-stackable0.0.0-dev_zookeeper-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev_openshift-true]                           
INFO:root:Expanding test case id [authorizer_druid-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_opa-0.45.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]
INFO:root:Expanding test case id [ingestion-no-s3-ext_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]
INFO:root:Expanding test case id [ingestion-s3-ext_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]
INFO:root:Expanding test case id [s3-deep-storage_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_s3-use-tls-true] 
INFO:root:Expanding test case id [hdfs-deep-storage_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]
INFO:root:Expanding test case id [resources_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev]
INFO:root:Expanding test case id [orphaned-resources_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]
INFO:root:Expanding test case id [tls_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_tls-mode-internal-and-server-tls-and-tls-client-auth_openshift-true]
INFO:root:Expanding test case id [ldap-authentication_druid-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_opa-0.45.0-stackable0.0.0-dev_hadoop-latest-3.3.4-stackable0.0.0-dev_ldap-use-tls-true_ldap-no-bin
d-credentials-false_openshift-true]                                                                                                                                                                                               
INFO:root:Expanding test case id [logging_druid-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-3.3.4-stackable0.0.0-dev]                                                                              
INFO:root:Expanding test case id [cluster-operation_druid-latest-26.0.0-stackable0.0.0-dev_zookeeper-latest-3.8.0-stackable0.0.0-dev_hadoop-latest-3.3.4-stackable0.0.0-dev]
(stackable) ➜  druid-operator git:(main) ✗                                                                                                                                   
```