### PR TITLE
tests: added namespace patch for openshift tests

### DIFF
--- a/tests/release.yaml
+++ b/tests/release.yaml
@@ -1,7 +1,7 @@
 # Contains all operators required to run the test suite.
 ---
 releases:
-  # Do not change the name of the release as it's referenced from run_tests.sh
+  # Do not change the name of the release as it's referenced from run-tests
   tests:
     releaseDate: 1970-01-01
     description: Integration test

--- a/tests/templates/kuttl/authorizer/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/authorizer/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/hdfs-deep-storage/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/hdfs-deep-storage/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/ingestion-no-s3-ext/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/ingestion-no-s3-ext/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/ingestion-s3-ext/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/ingestion-s3-ext/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/ldap-authentication/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/ldap-authentication/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/logging/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/oidc/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/oidc/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/orphaned-resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/resources/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/s3-deep-storage/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/s3-deep-storage/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/smoke/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/templates/kuttl/tls/00-patch-ns.yaml.j2
+++ b/tests/templates/kuttl/tls/00-patch-ns.yaml.j2
@@ -1,0 +1,9 @@
+{% if test_scenario['values']['openshift'] == 'true' %}
+# see https://github.com/stackabletech/issues/issues/566
+---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+commands:
+  - script: kubectl patch namespace $NAMESPACE -p '{"metadata":{"labels":{"pod-security.kubernetes.io/enforce":"privileged"}}}'
+    timeout: 120
+{% endif %}

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -67,35 +67,42 @@ tests:
       - zookeeper-latest
       - opa
       - hadoop
+      - openshift
   - name: ingestion-no-s3-ext
     dimensions:
       - druid-latest
       - zookeeper-latest
       - hadoop
+      - openshift
   - name: ingestion-s3-ext
     dimensions:
       - druid-latest
       - zookeeper-latest
       - hadoop
+      - openshift
   - name: s3-deep-storage
     dimensions:
       - druid-latest
       - zookeeper-latest
       - s3-use-tls
+      - openshift
   - name: hdfs-deep-storage
     dimensions:
       - druid-latest
       - hadoop
       - zookeeper-latest
+      - openshift
   - name: resources
     dimensions:
       - druid-latest
       - zookeeper-latest
+      - openshift
   - name: orphaned-resources
     dimensions:
       - druid-latest
       - zookeeper-latest
       - hadoop
+      - openshift
   - name: tls
     dimensions:
       - druid-latest
@@ -116,11 +123,13 @@ tests:
       - druid
       - hadoop
       - zookeeper-latest
+      - openshift
   - name: cluster-operation
     dimensions:
       - zookeeper-latest
       - hadoop-latest
       - druid-latest
+      - openshift
   - name: oidc
     dimensions:
       - druid-latest


### PR DESCRIPTION
# Description

Part of stackabletech/issues#566.

OKD:

```
--- PASS: kuttl (5423.66s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/s3-deep-storage_druid-latest-28.0.1_zookeeper-latest-3.9.1_s3-use-tls-true_openshift-true (596.11s)
        --- PASS: kuttl/harness/resources_druid-latest-28.0.1_zookeeper-latest-3.9.1_openshift-true (181.74s)
        --- PASS: kuttl/harness/hdfs-deep-storage_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-true (474.69s)
        --- PASS: kuttl/harness/tls_druid-latest-28.0.1_zookeeper-latest-3.9.1_tls-mode-internal-and-server-tls-and-tls-client-auth_openshift-true (379.50s)
        --- PASS: kuttl/harness/oidc_druid-latest-28.0.1_zookeeper-latest-3.9.1_s3-use-tls-true_openshift-true (339.05s)
        --- PASS: kuttl/harness/authorizer_druid-28.0.1_zookeeper-latest-3.9.1_opa-0.61.0_hadoop-3.3.6_openshift-true (417.67s)
        --- PASS: kuttl/harness/cluster-operation_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-latest-3.3.6_openshift-true (508.67s)
        --- PASS: kuttl/harness/smoke_druid-28.0.1_zookeeper-3.8.3_hadoop-3.3.6_openshift-true (332.31s)
        --- PASS: kuttl/harness/orphaned-resources_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-true (510.39s)
        --- PASS: kuttl/harness/logging_druid-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-true (345.98s)
        --- PASS: kuttl/harness/ingestion-no-s3-ext_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-true (455.73s)
        --- PASS: kuttl/harness/ingestion-s3-ext_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-true (489.44s)
        --- PASS: kuttl/harness/ldap-authentication_druid-28.0.1_zookeeper-latest-3.9.1_opa-0.61.0_hadoop-latest-3.3.6_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-true (383.73s)

```

Azure:

```
--- PASS: kuttl (2285.73s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/s3-deep-storage_druid-latest-28.0.1_zookeeper-latest-3.9.1_s3-use-tls-true_openshift-false (290.85s)
        --- PASS: kuttl/harness/smoke_druid-28.0.1_zookeeper-3.8.3_hadoop-3.3.6_openshift-false (350.87s)
        --- PASS: kuttl/harness/resources_druid-latest-28.0.1_zookeeper-latest-3.9.1_openshift-false (158.02s)
        --- PASS: kuttl/harness/hdfs-deep-storage_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-false (331.27s)
        --- PASS: kuttl/harness/authorizer_druid-28.0.1_zookeeper-latest-3.9.1_opa-0.61.0_hadoop-3.3.6_openshift-false (290.71s)
        --- PASS: kuttl/harness/logging_druid-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-false (269.85s)
        --- PASS: kuttl/harness/oidc_druid-latest-28.0.1_zookeeper-latest-3.9.1_s3-use-tls-true_openshift-false (222.90s)
        --- PASS: kuttl/harness/ldap-authentication_druid-28.0.1_zookeeper-latest-3.9.1_opa-0.61.0_hadoop-latest-3.3.6_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (286.29s)
        --- PASS: kuttl/harness/tls_druid-latest-28.0.1_zookeeper-latest-3.9.1_tls-mode-internal-and-server-tls_openshift-false (318.78s)
        --- PASS: kuttl/harness/tls_druid-latest-28.0.1_zookeeper-latest-3.9.1_tls-mode-no-tls_openshift-false (271.59s)
        --- PASS: kuttl/harness/cluster-operation_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-latest-3.3.6_openshift-false (402.65s)
        --- PASS: kuttl/harness/ingestion-s3-ext_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-false (349.30s)
        --- PASS: kuttl/harness/tls_druid-latest-28.0.1_zookeeper-latest-3.9.1_tls-mode-internal-and-server-tls-and-tls-client-auth_openshift-false (256.03s)
        --- PASS: kuttl/harness/orphaned-resources_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-false (348.67s)
        --- PASS: kuttl/harness/ingestion-no-s3-ext_druid-latest-28.0.1_zookeeper-latest-3.9.1_hadoop-3.3.6_openshift-false (343.39s)
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
