### PR TITLE
Docs: Fix broken link to deep storage documentation

### DIFF
--- a/docs/modules/druid/pages/usage-guide/deep-storage.adoc
+++ b/docs/modules/druid/pages/usage-guide/deep-storage.adoc
@@ -1,6 +1,6 @@
 = Deep storage configuration
 
-https://druid.apache.org/docs/latest/dependencies/deep-storage.html[Deep Storage] is where Druid stores data segments. For a Kubernetes environment, either the HDFS or S3 backend is recommended.
+https://druid.apache.org/docs/latest/design/deep-storage/[Deep Storage] is where Druid stores data segments. For a Kubernetes environment, either the HDFS or S3 backend is recommended.
 
 == [[hdfs]]HDFS
 


### PR DESCRIPTION
# Description
The documentation for deep storage has moved: https://druid.apache.org/docs/latest/design/deep-storage/


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes
 
```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
