### PR TITLE
chore: Remove custom schema workaround for HashSet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add support for specifying additional extensions to load ([#547])
+- Add support for specifying additional extensions to load ([#547], [#XXX])
+
+[#547]: https://github.com/stackabletech/druid-operator/pull/547
 
 ## [24.3.0] - 2024-03-20
 
@@ -23,7 +25,6 @@ All notable changes to this project will be documented in this file.
 [#494]: https://github.com/stackabletech/druid-operator/pull/494
 [#509]: https://github.com/stackabletech/druid-operator/pull/509
 [#518]: https://github.com/stackabletech/druid-operator/pull/518
-[#547]: https://github.com/stackabletech/druid-operator/pull/547
 
 ## [23.11.0] - 2023-11-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
-- Add support for specifying additional extensions to load ([#547], [#XXX])
+- Add support for specifying additional extensions to load ([#547], [#563])
 
 [#547]: https://github.com/stackabletech/druid-operator/pull/547
+[#563]: https://github.com/stackabletech/druid-operator/pull/563
 
 ## [24.3.0] - 2024-03-20
 

--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -44,7 +44,7 @@ use stackable_operator::{
         spec::Logging,
     },
     role_utils::{CommonConfiguration, GenericRoleConfig, Role, RoleGroup},
-    schemars::{self, schema::Schema, JsonSchema},
+    schemars::{self, JsonSchema},
     status::condition::{ClusterCondition, HasStatusCondition},
     time::Duration,
     utils::COMMON_BASH_TRAP_FUNCTIONS,
@@ -242,7 +242,6 @@ pub struct DruidClusterConfig {
     /// sometimes be necessary to load additional extensions.
     /// Add configuration for additional extensions using [configuration override for Druid](https://docs.stackable.tech/home/stable/druid/usage-guide/configuration-and-environment-overrides).
     #[serde(default)]
-    #[schemars(schema_with = "additional_extensions_schema")]
     pub additional_extensions: HashSet<String>,
 
     /// List of [AuthenticationClasses](DOCS_BASE_URL_PLACEHOLDER/concepts/authentication)
@@ -307,21 +306,6 @@ pub struct DruidClusterConfig {
     /// will be used to expose the service, and ListenerClass names will stay the same, allowing for a non-breaking change.
     #[serde(default)]
     pub listener_class: CurrentlySupportedListenerClasses,
-}
-
-/// TODO: Remove once kube-rs is fixed.
-/// Currently using HashSets and BTreeMaps in the schema will result in an invalid CRD that is rejected by the kube-apiserver with
-/// error message `Forbidden: uniqueItems cannot be set to true since the runtime complexity becomes quadratic`.
-/// This issue will be fixed in kube-rs by `<https://github.com/kube-rs/kube/pull/1484>`
-pub fn additional_extensions_schema(gen: &mut schemars::gen::SchemaGenerator) -> Schema {
-    let mut schema = HashSet::<String>::json_schema(gen);
-
-    if let Schema::Object(schema) = &mut schema {
-        let array = schema.array();
-        array.unique_items = None;
-    }
-
-    schema
 }
 
 // TODO: Temporary solution until listener-operator is finished


### PR DESCRIPTION
# Description

Leftover of #547.
As we now have access to https://github.com/kube-rs/kube/pull/1484, we can get rid of the workaround

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
