### PR TITLE
fix: JVM truststore & keystore location

### DIFF
--- a/rust/crd/src/lib.rs
+++ b/rust/crd/src/lib.rs
@@ -68,7 +68,7 @@ pub const LOG4J2_CONFIG: &str = "log4j2.properties";
 pub const JVM_SECURITY_PROPERTIES_FILE: &str = "security.properties";
 
 // store directories
-pub const STACKABLE_TRUST_STORE: &str = "/stackable/truststore.p12";
+pub const STACKABLE_TRUST_STORE: &str = "/stackable/tls/truststore.p12";
 pub const STACKABLE_TRUST_STORE_PASSWORD: &str = "changeit";
 pub const CERTS_DIR: &str = "/stackable/certificates";
 pub const LOG_DIR: &str = "/stackable/log";


### PR DESCRIPTION
# Description

The TLS secret containing truststore and keystore is mounted at `/stackable/tls` which is already used in Druid-specific properties (e.g. `druid.auth.basic.ssl.trustStorePath`). The `pac4J` extension uses the JVM config to configure the trust store.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [x] Code contains useful comments
- [x] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [x] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
