### PR TITLE
Fix the OIDC test

### DIFF
--- a/tests/templates/kuttl/oidc/login.py
+++ b/tests/templates/kuttl/oidc/login.py
@@ -16,11 +16,14 @@ tls = os.environ['OIDC_USE_TLS']
 
 session = requests.Session()
 
+druid_router_service = f"druid-router-default.{namespace}.svc.cluster.local"
+keycloak_service = f"keycloak.{namespace}.svc.cluster.local"
+
 # Open Druid web UI which will redirect to OIDC login
-login_page = session.get("https://druid-router-default:9088/unified-console.html", verify=False, headers={'Content-type': 'application/json'})
-keycloak_base_url = f"https://keycloak.{namespace}.svc.cluster.local:8443" if tls == 'true' else f"http://keycloak.{namespace}.svc.cluster.local:8080"
+login_page = session.get(f"https://{druid_router_service}:9088/unified-console.html", verify=False, headers={'Content-type': 'application/json'})
+keycloak_base_url = f"https://{keycloak_service}:8443" if tls == 'true' else f"http://{keycloak_service}:8080"
 assert login_page.ok, "Redirection from Druid to Keycloak failed"
-assert login_page.url.startswith(f"{keycloak_base_url}/realms/test/protocol/openid-connect/auth?scope=openid+profile+email&response_type=code&redirect_uri=https%3A%2F%2Fdruid-router-default%3A9088%2Fdruid-ext%2Fdruid-pac4j%2Fcallback&state="), \
+assert login_page.url.startswith(f"{keycloak_base_url}/realms/test/protocol/openid-connect/auth?scope=openid+profile+email&response_type=code&redirect_uri=https%3A%2F%2F{druid_router_service}%3A9088%2Fdruid-ext%2Fdruid-pac4j%2Fcallback&state="), \
     "Redirection to Keycloak expected"
 
 # Login to keycloak with test user
@@ -32,5 +35,5 @@ welcome_page = session.post(authenticate_url, data={
 })
 
 assert welcome_page.ok, "Login failed"
-assert welcome_page.url == "https://druid-router-default:9088/unified-console.html", \
+assert welcome_page.url == f"https://{druid_router_service}:9088/unified-console.html", \
     "Redirection to the Druid web UI expected"


### PR DESCRIPTION
# Description

The OIDC test fails with the following error:

```
2024-06-18 01:20:49,555 DEBUG: Starting new HTTPS connection (1): druid-router-default:9088
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 467, in _make_request
    self._validate_conn(conn)
  File "/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py", line 1099, in _validate_conn
    conn.connect()
  File "/usr/local/lib/python3.12/site-packages/urllib3/connection.py", line 653, in connect
    sock_and_verified = _ssl_wrap_socket_and_match_hostname(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/connection.py", line 806, in _ssl_wrap_socket_and_match_hostname
    ssl_sock = ssl_wrap_socket(
               ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/util/ssl_.py", line 465, in ssl_wrap_socket
    ssl_sock = _ssl_wrap_socket_impl(sock, context, tls_in_tls, server_hostname)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/urllib3/util/ssl_.py", line 509, in _ssl_wrap_socket_impl
    return ssl_context.wrap_socket(sock, server_hostname=server_hostname)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ssl.py", line 455, in wrap_socket
    return self.sslsocket_class._create(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/ssl.py", line 1042, in _create
    self.do_handshake()
  File "/usr/local/lib/python3.12/ssl.py", line 1320, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Hostname mismatch, certificate is not valid for 'druid-router-default'. (_ssl.c:1000)
```

The problem is that the certificate contains the fully-qualified service names (`druid-router-default.NAMESPACE.svc.cluster.local` and `druid-router-default-0.druid-router-default.NAMESPACE.svc.cluster.local`) but not the single hostname.

In prior test runs, this issue also existed but it was ignored:

```
2024-06-15 00:48:36,963 DEBUG: Starting new HTTPS connection (1): druid-router-default:9088
/usr/local/lib/python3.12/site-packages/urllib3/connectionpool.py:1103: InsecureRequestWarning: Unverified HTTPS request is being made to host 'druid-router-default'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
```

This pull request fixes this issue by using the fully-qualified service name.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [x] Integration tests passed (for non trivial changes)
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
