### PR TITLE
Remove stackableVersion from ZookeeperCluster CRD

### DIFF
--- a/tests/templates/kuttl/oidc/20-zookeeper.yaml
+++ b/tests/templates/kuttl/oidc/20-zookeeper.yaml
@@ -6,7 +6,6 @@ metadata:
 spec:
   image:
     productVersion: 3.8.1
-    stackableVersion: 23.7.0
     pullPolicy: IfNotPresent
   servers:
     roleGroups:

--- a/tests/templates/kuttl/oidc/20-zookeeper.yaml
+++ b/tests/templates/kuttl/oidc/20-zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: zk
 spec:
   image:
-    productVersion: 3.8.1
+    productVersion: "{{ test_scenario['values']['zookeeper-latest'] }}"
     pullPolicy: IfNotPresent
   servers:
     roleGroups:

--- a/tests/templates/kuttl/oidc/40_druid.yaml.j2
+++ b/tests/templates/kuttl/oidc/40_druid.yaml.j2
@@ -25,7 +25,7 @@ metadata:
   name: druid
 spec:
   image:
-    productVersion: 28.0.1
+    productVersion: "{{ test_scenario['values']['druid-latest'] }}"
     pullPolicy: IfNotPresent
   clusterConfig:
     additionalExtensions:


### PR DESCRIPTION
# Description

Fixing hardcoded
`stackableVersion: 23.7.0`

as it broke integration tests on ARM and is not supposed to be used anymore as we have `ImageSelection` by operator version.


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs-style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
