### PR TITLE
Fix broken AuthenticationClass link in docs

### DIFF
--- a/docs/modules/druid/pages/usage-guide/security.adoc
+++ b/docs/modules/druid/pages/usage-guide/security.adoc
@@ -72,7 +72,7 @@ include::example$druid-ldap-authentication.yaml[tag=druid]
 ----
 
 Check out the xref:tutorials:authentication_with_openldap.adoc[] tutorial to see a complete example of how to set LDAP authentication for another Stackable operator.
-You can also consult the xref:home:reference:authenticationclass.adoc[] reference, or
+You can also consult the xref:concepts:authentication.adoc#authenticationclass[AuthenticationClass] reference, or
 https://github.com/stackabletech/druid-operator/tree/main/tests/templates/kuttl/ldap-authentication[the LDAP test] suite.
 
 === OIDC


### PR DESCRIPTION
This currently breaks the build of our docs.

I tested the fix locally, works.