### PR TITLE
docs(getting-started): Make zookeeper templating variable consistent with other operators

### DIFF
--- a/docs/modules/druid/examples/getting_started/getting_started.sh
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 #   hdfs: 0.0.0-dev
 #   listener: 0.0.0-dev
 #   secret: 0.0.0-dev
-#   zk: 0.0.0-dev
+#   zookeeper: 0.0.0-dev
 # EOF
 
 # The getting started guide script

--- a/docs/modules/druid/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh.j2
@@ -13,7 +13,7 @@ set -euo pipefail
 #   hdfs: 0.0.0-dev
 #   listener: 0.0.0-dev
 #   secret: 0.0.0-dev
-#   zk: 0.0.0-dev
+#   zookeeper: 0.0.0-dev
 # EOF
 
 # The getting started guide script
@@ -47,7 +47,7 @@ echo "Installing Operators with Helm"
 helm install --wait commons-operator {{ helm.repo_name }}/commons-operator --version {{ versions.commons }}
 helm install --wait secret-operator {{ helm.repo_name }}/secret-operator --version {{ versions.secret }}
 helm install --wait listener-operator {{ helm.repo_name }}/listener-operator --version {{ versions.listener }}
-helm install --wait zookeeper-operator {{ helm.repo_name }}/zookeeper-operator --version {{ versions.zk }}
+helm install --wait zookeeper-operator {{ helm.repo_name }}/zookeeper-operator --version {{ versions.zookeeper }}
 helm install --wait hdfs-operator {{ helm.repo_name }}/hdfs-operator --version {{ versions.hdfs }}
 helm install --wait druid-operator {{ helm.repo_name }}/druid-operator --version {{ versions.druid }}
 # end::helm-install-operators[]
@@ -59,7 +59,7 @@ stackablectl operator install \
   commons={{ versions.commons }} \
   secret={{ versions.secret }} \
   listener={{ versions.listener }} \
-  zookeeper={{ versions.zk }} \
+  zookeeper={{ versions.zookeeper }} \
   hdfs={{ versions.hdfs }} \
   druid={{ versions.druid }}
 # end::stackablectl-install-operators[]

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -6,6 +6,6 @@ versions:
   commons: 0.0.0-dev
   secret: 0.0.0-dev
   listener: 0.0.0-dev
-  zk: 0.0.0-dev
+  zookeeper: 0.0.0-dev
   hdfs: 0.0.0-dev
   druid: 0.0.0-dev


### PR DESCRIPTION
Left over from https://github.com/stackabletech/druid-operator/pull/589

Only doc template changes