### PR TITLE
test: Set all graceful shutdown timeouts in integrations tests to 1s

### DIFF
--- a/tests/templates/kuttl/authorizer/04-install-druid.yaml.j2
+++ b/tests/templates/kuttl/authorizer/04-install-druid.yaml.j2
@@ -38,6 +38,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     configOverrides:
@@ -68,6 +69,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     configOverrides:
@@ -77,6 +79,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     configOverrides:
@@ -86,6 +89,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     configOverrides:
@@ -95,6 +99,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     configOverrides:

--- a/tests/templates/kuttl/cluster-operation/30-install-druid.yaml.j2
+++ b/tests/templates/kuttl/cluster-operation/30-install-druid.yaml.j2
@@ -32,6 +32,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -39,6 +40,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -46,6 +48,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -53,6 +56,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -60,6 +64,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/hdfs-deep-storage/03-install-druid.yaml.j2
+++ b/tests/templates/kuttl/hdfs-deep-storage/03-install-druid.yaml.j2
@@ -34,6 +34,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -41,6 +42,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -48,6 +50,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -55,6 +58,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       resources:
         cpu:
           min: 400m
@@ -68,6 +72,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/ingestion-no-s3-ext/03-install-druid.yaml.j2
+++ b/tests/templates/kuttl/ingestion-no-s3-ext/03-install-druid.yaml.j2
@@ -34,6 +34,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -41,6 +42,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -48,6 +50,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -55,6 +58,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -62,6 +66,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/ingestion-s3-ext/03-install-druid.yaml.j2
+++ b/tests/templates/kuttl/ingestion-s3-ext/03-install-druid.yaml.j2
@@ -40,6 +40,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -47,6 +48,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -54,6 +56,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -61,6 +64,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -68,6 +72,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/logging/05-install-druid.yaml.j2
+++ b/tests/templates/kuttl/logging/05-install-druid.yaml.j2
@@ -48,6 +48,8 @@ spec:
     vectorAggregatorConfigMapName: druid-vector-aggregator-discovery
     zookeeperConfigMapName: druid-znode
   brokers:
+    config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
     roleGroups:
       automatic-log-config:
         replicas: 1
@@ -100,6 +102,8 @@ spec:
                 custom:
                   configMap: druid-log-config
   coordinators:
+    config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
     roleGroups:
       automatic-log-config:
         replicas: 1
@@ -141,6 +145,8 @@ spec:
                 custom:
                   configMap: druid-log-config
   historicals:
+    config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
     roleGroups:
       automatic-log-config:
         replicas: 1
@@ -182,6 +188,8 @@ spec:
                 custom:
                   configMap: druid-log-config
   middleManagers:
+    config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
     roleGroups:
       automatic-log-config:
         replicas: 1
@@ -223,6 +231,8 @@ spec:
                 custom:
                   configMap: druid-log-config
   routers:
+    config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
     roleGroups:
       automatic-log-config:
         replicas: 1

--- a/tests/templates/kuttl/orphaned-resources/03-install-druid.yaml.j2
+++ b/tests/templates/kuttl/orphaned-resources/03-install-druid.yaml.j2
@@ -34,6 +34,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -41,6 +42,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -48,6 +50,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -55,6 +58,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -62,6 +66,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/resources/30-install-druid.yaml.j2
+++ b/tests/templates/kuttl/resources/30-install-druid.yaml.j2
@@ -38,6 +38,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
       resources:
@@ -51,6 +52,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
       resources:
@@ -64,6 +66,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
       resources:
@@ -79,6 +82,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
       resources:
@@ -92,6 +96,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
       resources:

--- a/tests/templates/kuttl/s3-deep-storage/10-install-druid.yaml.j2
+++ b/tests/templates/kuttl/s3-deep-storage/10-install-druid.yaml.j2
@@ -70,6 +70,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -77,6 +78,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -84,6 +86,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -91,6 +94,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -98,6 +102,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/smoke/50-assert.yaml
+++ b/tests/templates/kuttl/smoke/50-assert.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 1
 status:
   readyReplicas: 1
   replicas: 1
@@ -24,7 +24,7 @@ metadata:
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 1
 status:
   readyReplicas: 1
   replicas: 1
@@ -36,7 +36,7 @@ metadata:
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 1
       volumes:
         - name: tls-mount
           ephemeral:
@@ -74,7 +74,7 @@ metadata:
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 1
 status:
   readyReplicas: 1
   replicas: 1
@@ -86,7 +86,7 @@ metadata:
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 300
+      terminationGracePeriodSeconds: 1
 status:
   readyReplicas: 1
   replicas: 1

--- a/tests/templates/kuttl/smoke/50-install-druid.yaml.j2
+++ b/tests/templates/kuttl/smoke/50-install-druid.yaml.j2
@@ -35,6 +35,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -42,6 +43,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -49,6 +51,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -56,6 +59,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -63,6 +67,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:

--- a/tests/templates/kuttl/tls/04-install-druid.yaml.j2
+++ b/tests/templates/kuttl/tls/04-install-druid.yaml.j2
@@ -100,6 +100,7 @@ spec:
     zookeeperConfigMapName: druid-znode
   brokers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -107,6 +108,7 @@ spec:
         replicas: 1
   coordinators:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -114,6 +116,7 @@ spec:
         replicas: 1
   historicals:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -121,6 +124,7 @@ spec:
         replicas: 1
   middleManagers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:
@@ -128,6 +132,7 @@ spec:
         replicas: 1
   routers:
     config:
+      gracefulShutdownTimeout: 1s # Let the test run faster
       logging:
         enableVectorAgent: {{ lookup('env', 'VECTOR_AGGREGATOR') | length > 0 }}
     roleGroups:


### PR DESCRIPTION
# Description

This change allows to quickly delete namespaces after an integration test completed.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
