### PR TITLE
test(kuttl): Remove the -o pipefail bash option

### DIFF
--- a/tests/templates/kuttl/overrides/21-assert.yaml
+++ b/tests/templates/kuttl/overrides/21-assert.yaml
@@ -7,8 +7,7 @@ commands:
   # Test envOverrides
   #
   - script: |
-      #!/usr/bin/env bash
-      set -euo pipefail
+      set -eu
 
       # STS Spec Test Data
       DRUID_BROKER_STS=$( kubectl -n "$NAMESPACE" get sts druid-broker-default -o yaml )

--- a/tests/templates/kuttl/overrides/22-assert.yaml
+++ b/tests/templates/kuttl/overrides/22-assert.yaml
@@ -7,8 +7,7 @@ commands:
   # Test configOverrides
   #
   - script: |
-      #!/usr/bin/env bash
-      set -euo pipefail
+      set -eu
 
       # Config Test Data
       DRUID_BROKER_CONFIG=$(


### PR DESCRIPTION
Kuttl hard codes `sh -c`, instead of allowing alternative shells to be used.
For now, we need to drop the `-o pipefail` option.

I think https://github.com/kudobuilder/kuttl/issues/50 was incorrectly closed, as the issue author asked for "bash script".

> [!NOTE]
> For Macos and NixOs users, `sh` appears to work like bash, so locally `set -euo pipfail` worked fine.