### PR TITLE
fix(docs): Update getting-started script pre-24.11

### DIFF
--- a/docs/modules/druid/examples/getting_started/getting_started.sh
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh
@@ -114,7 +114,7 @@ kubectl rollout status --watch statefulset/simple-hdfs-namenode-default --timeou
 
 echo "Install DruidCluster from druid.yaml"
 # tag::install-druid[]
-kubectl apply -f druid.yaml
+kubectl apply --server-side -f druid.yaml
 # end::install-druid[]
 
 for (( i=1; i<=15; i++ ))

--- a/docs/modules/druid/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh.j2
@@ -114,7 +114,7 @@ kubectl rollout status --watch statefulset/simple-hdfs-namenode-default --timeou
 
 echo "Install DruidCluster from druid.yaml"
 # tag::install-druid[]
-kubectl apply -f druid.yaml
+kubectl apply --server-side -f druid.yaml
 # end::install-druid[]
 
 for (( i=1; i<=15; i++ ))


### PR DESCRIPTION
# Check and Update Getting Started Script

<!--
    Make sure to update the link in 'issues/.github/ISSUE_TEMPLATE/pre-release-getting-started-scripts.md'
    when you rename this file.
-->

<!--
    Replace 'TRACKING_ISSUE' with the applicable release tracking issue number.
-->

Part of https://github.com/stackabletech/issues/issues/657.
Uses `--server-side` for deploying druid resource so that `null` fields are honoured.

> [!NOTE]
> During a Stackable release we need to check (and optionally update) the
> getting-started scripts to ensure they still work after product and operator
> updates.

```shell
# Some of the scripts are in a code/ subdirectory
# pushd docs/modules/superset/examples/getting_started
# pushd docs/modules/superset/examples/getting_started/code
pushd $(fd -td getting_started | grep examples); cd code 2>/dev/null || true

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm

popd
```
