### PR TITLE
chore(docs): Update getting-started script pre-25.3.0

### DIFF
--- a/docs/modules/druid/examples/getting_started/getting_started.sh
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh
@@ -102,13 +102,12 @@ kubectl rollout status --watch statefulset/simple-hdfs-namenode-default --timeou
 
 echo "Installing PostgreSQL for Druid"
 # tag::helm-install-postgres[]
-helm install postgresql-druid \
---repo https://charts.bitnami.com/bitnami postgresql \
---version 16.1.2 \
---set auth.database=druid \
---set auth.username=druid \
---set auth.password=druid \
---wait
+helm install postgresql-druid oci://registry-1.docker.io/bitnamicharts/postgresql \
+  --version 16.5.0 \
+  --set auth.database=druid \
+  --set auth.username=druid \
+  --set auth.password=druid \
+  --wait
 # end::helm-install-postgres[]
 
 echo "Install DruidCluster from druid.yaml"

--- a/docs/modules/druid/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh.j2
@@ -102,13 +102,12 @@ kubectl rollout status --watch statefulset/simple-hdfs-namenode-default --timeou
 
 echo "Installing PostgreSQL for Druid"
 # tag::helm-install-postgres[]
-helm install postgresql-druid \
---repo https://charts.bitnami.com/bitnami postgresql \
---version 16.1.2 \
---set auth.database=druid \
---set auth.username=druid \
---set auth.password=druid \
---wait
+helm install postgresql-druid oci://registry-1.docker.io/bitnamicharts/postgresql \
+  --version {{ versions.postgresql }} \
+  --set auth.database=druid \
+  --set auth.username=druid \
+  --set auth.password=druid \
+  --wait
 # end::helm-install-postgres[]
 
 echo "Install DruidCluster from druid.yaml"

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -9,3 +9,4 @@ versions:
   zookeeper: 0.0.0-dev
   hdfs: 0.0.0-dev
   druid: 0.0.0-dev
+  postgresql: 16.5.0


### PR DESCRIPTION
# Check and Update Getting Started Script

Part of <https://github.com/stackabletech/issues/issues/697>

This PR bumps the `postgresql` chart to 16.5.0

```shell
# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh stackablectl

# Make a fresh cluster (~12 seconds)
kind delete cluster && kind create cluster
./getting_started.sh helm
```
