### PR TITLE
docs: Update helm install commands

### DIFF
--- a/docs/modules/druid/examples/getting_started/getting_started.sh
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh
@@ -24,20 +24,14 @@ cd "$(dirname "$0")"
 
 case "$1" in
 "helm")
-echo "Adding 'stackable-dev' Helm Chart repository"
-# tag::helm-add-repo[]
-helm repo add stackable-dev https://repo.stackable.tech/repository/helm-dev/
-# end::helm-add-repo[]
-echo "Updating Helm repo"
-helm repo update
 echo "Installing Operators with Helm"
 # tag::helm-install-operators[]
-helm install --wait commons-operator stackable-dev/commons-operator --version 0.0.0-dev
-helm install --wait secret-operator stackable-dev/secret-operator --version 0.0.0-dev
-helm install --wait listener-operator stackable-dev/listener-operator --version 0.0.0-dev
-helm install --wait zookeeper-operator stackable-dev/zookeeper-operator --version 0.0.0-dev
-helm install --wait hdfs-operator stackable-dev/hdfs-operator --version 0.0.0-dev
-helm install --wait druid-operator stackable-dev/druid-operator --version 0.0.0-dev
+helm install --wait commons-operator oci://oci.stackable.tech/sdp-charts/commons-operator --version 0.0.0-dev
+helm install --wait secret-operator oci://oci.stackable.tech/sdp-charts/secret-operator --version 0.0.0-dev
+helm install --wait listener-operator oci://oci.stackable.tech/sdp-charts/listener-operator --version 0.0.0-dev
+helm install --wait zookeeper-operator oci://oci.stackable.tech/sdp-charts/zookeeper-operator --version 0.0.0-dev
+helm install --wait hdfs-operator oci://oci.stackable.tech/sdp-charts/hdfs-operator --version 0.0.0-dev
+helm install --wait druid-operator oci://oci.stackable.tech/sdp-charts/druid-operator --version 0.0.0-dev
 # end::helm-install-operators[]
 ;;
 "stackablectl")

--- a/docs/modules/druid/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh.j2
@@ -24,20 +24,14 @@ cd "$(dirname "$0")"
 
 case "$1" in
 "helm")
-echo "Adding '{{ helm.repo_name }}' Helm Chart repository"
-# tag::helm-add-repo[]
-helm repo add {{ helm.repo_name }} {{ helm.repo_url }}
-# end::helm-add-repo[]
-echo "Updating Helm repo"
-helm repo update
 echo "Installing Operators with Helm"
 # tag::helm-install-operators[]
-helm install --wait commons-operator {{ helm.repo_name }}/commons-operator --version {{ versions.commons }}
-helm install --wait secret-operator {{ helm.repo_name }}/secret-operator --version {{ versions.secret }}
-helm install --wait listener-operator {{ helm.repo_name }}/listener-operator --version {{ versions.listener }}
-helm install --wait zookeeper-operator {{ helm.repo_name }}/zookeeper-operator --version {{ versions.zookeeper }}
-helm install --wait hdfs-operator {{ helm.repo_name }}/hdfs-operator --version {{ versions.hdfs }}
-helm install --wait druid-operator {{ helm.repo_name }}/druid-operator --version {{ versions.druid }}
+helm install --wait commons-operator oci://{{ helm.repo_url }}/{{ helm.repo_name }}/commons-operator --version {{ versions.commons }}
+helm install --wait secret-operator oci://{{ helm.repo_url }}/{{ helm.repo_name }}/secret-operator --version {{ versions.secret }}
+helm install --wait listener-operator oci://{{ helm.repo_url }}/{{ helm.repo_name }}/listener-operator --version {{ versions.listener }}
+helm install --wait zookeeper-operator oci://{{ helm.repo_url }}/{{ helm.repo_name }}/zookeeper-operator --version {{ versions.zookeeper }}
+helm install --wait hdfs-operator oci://{{ helm.repo_url }}/{{ helm.repo_name }}/hdfs-operator --version {{ versions.hdfs }}
+helm install --wait druid-operator oci://{{ helm.repo_url }}/{{ helm.repo_name }}/druid-operator --version {{ versions.druid }}
 # end::helm-install-operators[]
 ;;
 "stackablectl")

--- a/docs/modules/druid/pages/getting_started/installation.adoc
+++ b/docs/modules/druid/pages/getting_started/installation.adoc
@@ -34,11 +34,7 @@ Helm::
 --
 You can also use Helm to install the operators.
 
-.Add the Stackable Helm repository
-[source,bash]
-----
-include::example$getting_started/getting_started.sh[tag=helm-add-repo]
-----
+NOTE: `helm repo` subcommands are not supported for OCI registries. The operators are installed directly, without adding the Helm Chart repository first.
 
 .Install the Stackable operators
 [source,bash]

--- a/docs/templating_vars.yaml
+++ b/docs/templating_vars.yaml
@@ -1,7 +1,7 @@
 ---
 helm:
-  repo_name: stackable-dev
-  repo_url: https://repo.stackable.tech/repository/helm-dev/
+  repo_name: sdp-charts
+  repo_url: oci.stackable.tech
 versions:
   commons: 0.0.0-dev
   secret: 0.0.0-dev


### PR DESCRIPTION
# Description

Part of https://github.com/stackabletech/infrastructure/issues/142
Updating the helm install commands in Getting started sections of the operators was missed during Harbor migration of the docs.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

```[tasklist]
# Author
- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
```

```[tasklist]
# Reviewer
- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)
```

```[tasklist]
# Acceptance
- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
```
