### PR TITLE
chore: Remove hardcoded uid and gid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ All notable changes to this project will be documented in this file.
     of having the operator write it to the vector config ([#704]).
 - test: Bump to Vector `0.46.1` ([#719]).
 - test: Bump OPA to `1.4.2` ([#721]).
+- BREAKING: Previously this operator would hardcode the UID and GID of the Pods being created to 1000/0, this has changed now ([#718])
+  - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
+  - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
+  - This is marked as breaking because tools and policies might exist, which require these fields to be set
 
 ### Fixed
 
@@ -39,6 +43,7 @@ All notable changes to this project will be documented in this file.
 [#710]: https://github.com/stackabletech/druid-operator/pull/710
 [#714]: https://github.com/stackabletech/druid-operator/pull/714
 [#716]: https://github.com/stackabletech/druid-operator/pull/716
+[#718]: https://github.com/stackabletech/druid-operator/pull/718
 [#719]: https://github.com/stackabletech/druid-operator/pull/719
 [#721]: https://github.com/stackabletech/druid-operator/pull/721
 

--- a/rust/operator-binary/src/druid_controller.rs
+++ b/rust/operator-binary/src/druid_controller.rs
@@ -88,7 +88,6 @@ use crate::{
 pub const DRUID_CONTROLLER_NAME: &str = "druidcluster";
 pub const FULL_CONTROLLER_NAME: &str = concatcp!(DRUID_CONTROLLER_NAME, '.', OPERATOR_NAME);
 
-const DRUID_UID: i64 = 1000;
 const DOCKER_IMAGE_BASE_NAME: &str = "druid";
 
 // volume names
@@ -1138,13 +1137,7 @@ fn build_rolegroup_statefulset(
         .add_container(cb_druid.build())
         .metadata(metadata)
         .service_account_name(service_account.name_any())
-        .security_context(
-            PodSecurityContextBuilder::new()
-                .run_as_user(DRUID_UID)
-                .run_as_group(0)
-                .fs_group(1000)
-                .build(),
-        );
+        .security_context(PodSecurityContextBuilder::new().fs_group(1000).build());
 
     if merged_rolegroup_config.logging.enable_vector_agent {
         match &druid.spec.cluster_config.vector_aggregator_config_map_name {


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/651

Remove hardcoded uid and gid, they'll default to the ones from the docker images now.
For 25.7 that means they might change from 1000/0
See https://github.com/stackabletech/docker-images/pull/916 for details

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Changes are OpenShift compatible
- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [x] Changelog updated

### Acceptance

- [ ] Proper release label has been added
