### PR TITLE
chore: Add support for 33.0.0, remove support for 30.0.0, deprecate 31.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
   - Use `--file-log-max-files` (or `FILE_LOG_MAX_FILES`) to limit the number of log files kept.
   - Use `--file-log-rotation-period` (or `FILE_LOG_ROTATION_PERIOD`) to configure the frequency of rotation.
   - Use `--console-log-format` (or `CONSOLE_LOG_FORMAT`) to set the format to `plain` (default) or `json`.
+- Add support for `33.0.0` ([#722]).
 
 ### Changed
 
@@ -27,6 +28,7 @@ All notable changes to this project will be documented in this file.
   - The `runAsUser` and `runAsGroup` fields will not be set anymore by the operator
   - The defaults from the docker images itself will now apply, which will be different from 1000/0 going forward
   - This is marked as breaking because tools and policies might exist, which require these fields to be set
+- Deprecate support for `31.0.1` ([#722]).
 
 ### Fixed
 
@@ -36,6 +38,7 @@ All notable changes to this project will be documented in this file.
 ### Removed
 
 - test: ZooKeeper 3.9.2 removed ([#716]).
+- Remove support for `30.0.0` ([#722]).
 
 [#703]: https://github.com/stackabletech/druid-operator/pull/703
 [#704]: https://github.com/stackabletech/druid-operator/pull/704
@@ -46,6 +49,7 @@ All notable changes to this project will be documented in this file.
 [#718]: https://github.com/stackabletech/druid-operator/pull/718
 [#719]: https://github.com/stackabletech/druid-operator/pull/719
 [#721]: https://github.com/stackabletech/druid-operator/pull/721
+[#722]: https://github.com/stackabletech/druid-operator/pull/722
 
 ## [25.3.0] - 2025-03-21
 

--- a/docs/modules/druid/examples/getting_started/druid.yaml
+++ b/docs/modules/druid/examples/getting_started/druid.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-druid
 spec:
   image:
-    productVersion: 31.0.1
+    productVersion: 33.0.0
   clusterConfig:
     listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
     zookeeperConfigMapName: simple-druid-znode

--- a/docs/modules/druid/examples/getting_started/druid.yaml.j2
+++ b/docs/modules/druid/examples/getting_started/druid.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-druid
 spec:
   image:
-    productVersion: 31.0.1
+    productVersion: 33.0.0
   clusterConfig:
     listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
     zookeeperConfigMapName: simple-druid-znode

--- a/docs/modules/druid/partials/supported-versions.adoc
+++ b/docs/modules/druid/partials/supported-versions.adoc
@@ -2,6 +2,6 @@
 // This is a separate file, since it is used by both the direct Druid documentation, and the overarching
 // Stackable Platform documentation.
 
-- 31.0.1
+- 33.0.0
+- 31.0.1 (deprecated)
 - 30.0.1 (LTS)
-- 30.0.0 (deprecated)

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -13,14 +13,14 @@
 dimensions:
   - name: druid
     values:
-      - 30.0.0
       - 30.0.1
       - 31.0.1
+      - 33.0.0
       # To use a custom image, add a comma and the full name after the product version
       # - 30.0.0,oci.stackable.tech/sdp/druid:30.0.0-stackable0.0.0-dev
   - name: druid-latest
     values:
-      - 31.0.1
+      - 33.0.0
       # To use a custom image, add a comma and the full name after the product version
       # - 30.0.0,oci.stackable.tech/sdp/druid:30.0.0-stackable0.0.0-dev
   - name: zookeeper


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1075.

- Add: `33.0.0`
- Deprecate: `31.0.1`
- Remove: `30.0.0`

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [x] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] [Roadmap](https://github.com/orgs/stackabletech/projects/25/views/1) has been updated
