### PR TITLE
tests: increase HdfsCluster assert timeout

### DIFF
--- a/tests/templates/kuttl/overrides/10-assert.yaml
+++ b/tests/templates/kuttl/overrides/10-assert.yaml
@@ -1,4 +1,8 @@
 ---
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 600
+---
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/tests/templates/kuttl/overrides/10-install-hdfs.yaml.j2
+++ b/tests/templates/kuttl/overrides/10-install-hdfs.yaml.j2
@@ -1,4 +1,10 @@
 ---
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+metadata:
+  name: druid-hdfs
+timeout: 600
+---
 apiVersion: hdfs.stackable.tech/v1alpha1
 kind: HdfsCluster
 metadata:


### PR DESCRIPTION
## Description

The "overrides" test still had the default timeout of 5 minutes to wait for the HdfsCluster, which is a bit short and sometimes caused the test to fail. I adjusted it to 10 minutes, like in the other tests.

Successful test: https://testing.stackable.tech/job/druid-operator-it-custom/52/

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
