### PR TITLE
fix: Add RBAC permission to patch events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ All notable changes to this project will be documented in this file.
   - The default Kubernetes cluster domain name is now fetched from the kubelet API unless explicitly configured.
   - This requires operators to have the RBAC permission to get nodes/proxy in the apiGroup "". The helm-chart takes care of this.
   - The CLI argument `--kubernetes-node-name` or env variable `KUBERNETES_NODE_NAME` needs to be set. The helm-chart takes care of this.
+- The operator helm-chart now grants RBAC `patch` permissions on `events.k8s.io/events`,
+  so events can be aggregated (e.g. "error happened 10 times over the last 5 minutes") ([#737]).
 
 ### Fixed
 
@@ -63,6 +65,7 @@ All notable changes to this project will be documented in this file.
 [#725]: https://github.com/stackabletech/druid-operator/pull/725
 [#731]: https://github.com/stackabletech/druid-operator/pull/731
 [#735]: https://github.com/stackabletech/druid-operator/pull/735
+[#737]: https://github.com/stackabletech/druid-operator/pull/737
 
 ## [25.3.0] - 2025-03-21
 

--- a/deploy/helm/druid-operator/templates/roles.yaml
+++ b/deploy/helm/druid-operator/templates/roles.yaml
@@ -172,6 +172,7 @@ rules:
       - events
     verbs:
       - create
+      - patch
 {{ if .Capabilities.APIVersions.Has "security.openshift.io/v1" }}
   - apiGroups:
       - security.openshift.io


### PR DESCRIPTION
Needed since https://github.com/stackabletech/operator-rs/pull/938

Not 100% sure why the product needs this, but it was this way before.
