### PR TITLE
chore: fix minio Chart values for bitnami migration

### DIFF
--- a/tests/templates/kuttl/oidc/04_helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/oidc/04_helm-bitnami-minio-values.yaml.j2
@@ -8,7 +8,8 @@ image:
 clientImage:
   repository: bitnamilegacy/minio-client
 defaultInitContainers:
-  volumePermissions:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
     image:
       repository: bitnamilegacy/os-shell
 console:
@@ -41,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/resources/02_helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/resources/02_helm-bitnami-minio-values.yaml.j2
@@ -8,7 +8,8 @@ image:
 clientImage:
   repository: bitnamilegacy/minio-client
 defaultInitContainers:
-  volumePermissions:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
     image:
       repository: bitnamilegacy/os-shell
 console:
@@ -41,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/s3-deep-storage/04_helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/s3-deep-storage/04_helm-bitnami-minio-values.yaml.j2
@@ -8,7 +8,8 @@ image:
 clientImage:
   repository: bitnamilegacy/minio-client
 defaultInitContainers:
-  volumePermissions:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
     image:
       repository: bitnamilegacy/os-shell
 console:
@@ -41,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false

--- a/tests/templates/kuttl/tls/03_helm-bitnami-minio-values.yaml.j2
+++ b/tests/templates/kuttl/tls/03_helm-bitnami-minio-values.yaml.j2
@@ -8,7 +8,8 @@ image:
 clientImage:
   repository: bitnamilegacy/minio-client
 defaultInitContainers:
-  volumePermissions:
+  volumePermissions: # volumePermissions moved under defaultInitContainers starting with Chart version 17.0.0
+    enabled: false
     image:
       repository: bitnamilegacy/os-shell
 console:
@@ -41,8 +42,11 @@ provisioning:
   containerSecurityContext:
     enabled: false
 
+# volumePermissions can be removed starting with Chart version 17.0.0, moved under defaultInitContainers
 volumePermissions:
   enabled: false
+  image:
+    repository: bitnamilegacy/os-shell
 
 podSecurityContext:
   enabled: false


### PR DESCRIPTION
## Description

Follow up to https://github.com/stackabletech/druid-operator/pull/744
Noticed in https://github.com/stackabletech/trino-operator/pull/784 that minio Chart values were incorrect for the installed version. Following up with a fix in this PR.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
