### PR TITLE
chore: update docs and examples to use bitnamilegacy

### DIFF
--- a/docs/modules/druid/examples/getting_started/druid.yaml
+++ b/docs/modules/druid/examples/getting_started/druid.yaml
@@ -23,13 +23,13 @@ spec:
       default:
         replicas: 1
     roleConfig:
-      listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-stable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
   coordinators:
     roleGroups:
       default:
         replicas: 1
     roleConfig:
-      listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-stable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
   historicals:
     roleGroups:
       default:
@@ -43,7 +43,7 @@ spec:
       default:
         replicas: 1
     roleConfig:
-      listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-stable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
 ---
 apiVersion: v1
 kind: Secret

--- a/docs/modules/druid/examples/getting_started/druid.yaml.j2
+++ b/docs/modules/druid/examples/getting_started/druid.yaml.j2
@@ -23,13 +23,13 @@ spec:
       default:
         replicas: 1
     roleConfig:
-      listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-stable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
   coordinators:
     roleGroups:
       default:
         replicas: 1
     roleConfig:
-      listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-stable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
   historicals:
     roleGroups:
       default:
@@ -43,7 +43,7 @@ spec:
       default:
         replicas: 1
     roleConfig:
-      listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-stable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
 ---
 apiVersion: v1
 kind: Secret

--- a/docs/modules/druid/examples/getting_started/getting_started.sh
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh
@@ -98,6 +98,10 @@ echo "Installing PostgreSQL for Druid"
 # tag::helm-install-postgres[]
 helm install postgresql-druid oci://registry-1.docker.io/bitnamicharts/postgresql \
   --version 16.5.0 \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set global.security.allowInsecureImages=true \
   --set auth.database=druid \
   --set auth.username=druid \
   --set auth.password=druid \

--- a/docs/modules/druid/examples/getting_started/getting_started.sh.j2
+++ b/docs/modules/druid/examples/getting_started/getting_started.sh.j2
@@ -98,6 +98,10 @@ echo "Installing PostgreSQL for Druid"
 # tag::helm-install-postgres[]
 helm install postgresql-druid oci://registry-1.docker.io/bitnamicharts/postgresql \
   --version {{ versions.postgresql }} \
+  --set image.repository=bitnamilegacy/postgresql \
+  --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+  --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+  --set global.security.allowInsecureImages=true \
   --set auth.database=druid \
   --set auth.username=druid \
   --set auth.password=druid \

--- a/docs/modules/druid/examples/getting_started/hdfs.yaml
+++ b/docs/modules/druid/examples/getting_started/hdfs.yaml
@@ -11,13 +11,13 @@ spec:
     zookeeperConfigMapName: simple-hdfs-znode
   nameNodes:
     config:
-      listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-stable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
     roleGroups:
       default:
         replicas: 2
   dataNodes:
     config:
-      listenerClass: external-unstable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-unstable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
     roleGroups:
       default:
         replicas: 1

--- a/docs/modules/druid/examples/getting_started/hdfs.yaml.j2
+++ b/docs/modules/druid/examples/getting_started/hdfs.yaml.j2
@@ -11,13 +11,13 @@ spec:
     zookeeperConfigMapName: simple-hdfs-znode
   nameNodes:
     config:
-      listenerClass: external-stable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-stable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
     roleGroups:
       default:
         replicas: 2
   dataNodes:
     config:
-      listenerClass: external-unstable # This exposes your Stacklet outside of Kubernetes. Remove this configuration if this is not desired
+      listenerClass: external-unstable # This exposes this role outside of Kubernetes. Remove this configuration if this is not desired
     roleGroups:
       default:
         replicas: 1

--- a/examples/psql-s3/README.md
+++ b/examples/psql-s3/README.md
@@ -7,6 +7,10 @@ And setup the Postgres database:
 
     helm install druid bitnami/postgresql \
     --version=11 \
+    --set image.repository=bitnamilegacy/postgresql \
+    --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+    --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+    --set global.security.allowInsecureImages=true \
     --set auth.username=druid \
     --set auth.password=druid \
     --set auth.database=druid

--- a/examples/psql/README.md
+++ b/examples/psql/README.md
@@ -7,6 +7,10 @@ And setup the Postgres database:
 
     helm install druid bitnami/postgresql \
     --version=11 \
+    --set image.repository=bitnamilegacy/postgresql \
+    --set volumePermissions.image.repository=bitnamilegacy/os-shell \
+    --set metrics.image.repository=bitnamilegacy/postgres-exporter \
+    --set global.security.allowInsecureImages=true \
     --set auth.username=druid \
     --set auth.password=druid \
     --set auth.database=druid


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/issues/issues/749 and follow up to https://github.com/stackabletech/druid-operator/pull/744
This PR updates the docs and examples of the 25.7 release to use bitnamilegacy.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
