### PR TITLE
fix: Auto-create truststore on certificate addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Previously we had a bug that could lead to missing certificates ([#753], [#756]).
+- Fix keytool behavior that could lead to missing certificates ([#753], [#756]).
 
   This could be the case when the Stackable PKI rotated its CA certificate or you specified multiple
   CAs in your SecretClass.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Previously we had a bug that could lead to missing certificates ([#753]).
+- Previously we had a bug that could lead to missing certificates ([#753], [#756]).
 
   This could be the case when the Stackable PKI rotated its CA certificate or you specified multiple
   CAs in your SecretClass.
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 [#752]: https://github.com/stackabletech/druid-operator/pull/752
 [#753]: https://github.com/stackabletech/druid-operator/pull/753
 [#755]: https://github.com/stackabletech/druid-operator/pull/755
+[#756]: https://github.com/stackabletech/druid-operator/pull/756
 
 ## [25.7.0] - 2025-07-23
 

--- a/rust/operator-binary/src/authentication/ldap.rs
+++ b/rust/operator-binary/src/authentication/ldap.rs
@@ -100,7 +100,7 @@ pub fn prepare_container_commands(
     command: &mut Vec<String>,
 ) {
     if let Some(tls_ca_cert_mount_path) = provider.tls.tls_ca_cert_mount_path() {
-        command.push(add_cert_to_trust_store_cmd(
+        command.extend(add_cert_to_trust_store_cmd(
             &tls_ca_cert_mount_path,
             STACKABLE_TLS_DIR,
             TLS_STORE_PASSWORD,

--- a/rust/operator-binary/src/authentication/oidc.rs
+++ b/rust/operator-binary/src/authentication/oidc.rs
@@ -111,7 +111,7 @@ pub fn main_container_commands(
     command: &mut Vec<String>,
 ) {
     if let Some(tls_ca_cert_mount_path) = provider.tls.tls_ca_cert_mount_path() {
-        command.push(add_cert_to_jvm_trust_store_cmd(&tls_ca_cert_mount_path))
+        command.extend(add_cert_to_jvm_trust_store_cmd(&tls_ca_cert_mount_path))
     }
 }
 

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -997,7 +997,7 @@ impl DruidRole {
 
         if let Some(s3) = s3 {
             if let Some(ca_cert_file) = s3.tls.tls_ca_cert_mount_path() {
-                commands.push(add_cert_to_jvm_trust_store_cmd(&ca_cert_file));
+                commands.extend(add_cert_to_jvm_trust_store_cmd(&ca_cert_file));
             }
         }
 

--- a/rust/operator-binary/src/crd/security.rs
+++ b/rust/operator-binary/src/crd/security.rs
@@ -475,14 +475,14 @@ pub fn add_cert_to_trust_store_cmd(
     cert_file: &str,
     destination_directory: &str,
     store_password: &str,
-) -> String {
+) -> Vec<String> {
     let truststore = format!("{destination_directory}/truststore.p12");
-    format!(
-        "cert-tools generate-pkcs12-truststore --pkcs12 {truststore}:{store_password} --pem {cert_file} --out {truststore} --out-password {store_password}"
-    )
+    vec![format!(
+        "if [ -f {truststore} ]; then cert-tools generate-pkcs12-truststore --pkcs12 {truststore}:{store_password} --pem {cert_file} --out {truststore} --out-password {store_password}; else cert-tools generate-pkcs12-truststore --pem {cert_file} --out {truststore} --out-password {store_password}; fi" // "cert-tools generate-pkcs12-truststore --pkcs12 {truststore}:{store_password} --pem {cert_file} --out {truststore} --out-password {store_password}"
+    )]
 }
 
 /// Generate a bash command to add a CA to the truststore that is passed to the JVM
-pub fn add_cert_to_jvm_trust_store_cmd(cert_file: &str) -> String {
+pub fn add_cert_to_jvm_trust_store_cmd(cert_file: &str) -> Vec<String> {
     add_cert_to_trust_store_cmd(cert_file, "/stackable", STACKABLE_TRUST_STORE_PASSWORD)
 }

--- a/rust/operator-binary/src/crd/security.rs
+++ b/rust/operator-binary/src/crd/security.rs
@@ -478,7 +478,7 @@ pub fn add_cert_to_trust_store_cmd(
 ) -> Vec<String> {
     let truststore = format!("{destination_directory}/truststore.p12");
     vec![format!(
-        "if [ -f {truststore} ]; then cert-tools generate-pkcs12-truststore --pkcs12 {truststore}:{store_password} --pem {cert_file} --out {truststore} --out-password {store_password}; else cert-tools generate-pkcs12-truststore --pem {cert_file} --out {truststore} --out-password {store_password}; fi" // "cert-tools generate-pkcs12-truststore --pkcs12 {truststore}:{store_password} --pem {cert_file} --out {truststore} --out-password {store_password}"
+        "if [ -f {truststore} ]; then cert-tools generate-pkcs12-truststore --pkcs12 {truststore}:{store_password} --pem {cert_file} --out {truststore} --out-password {store_password}; else cert-tools generate-pkcs12-truststore --pem {cert_file} --out {truststore} --out-password {store_password}; fi"
     )]
 }
 

--- a/tests/templates/kuttl/ldap/20-assert.yaml
+++ b/tests/templates/kuttl/ldap/20-assert.yaml
@@ -3,4 +3,4 @@ apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
 commands:
   - script: kubectl exec -n $NAMESPACE test-druid-0 -- python /tmp/authcheck.py
-timeout: 60
+timeout: 180


### PR DESCRIPTION
## Description

While checking this I noticed TLS handling in druid-operator looks buggy to me.
Given it's Druid I did not further investigate, but restored the previous behavior of `keytool`.
The test should now pass again.

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
