### PR TITLE
chore: Bump hadoop to 3.4.2 prior to 25.11

### DIFF
--- a/docs/modules/druid/examples/getting_started/hdfs.yaml
+++ b/docs/modules/druid/examples/getting_started/hdfs.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-hdfs
 spec:
   image:
-    productVersion: 3.4.1
+    productVersion: 3.4.2
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: simple-hdfs-znode

--- a/docs/modules/druid/examples/getting_started/hdfs.yaml.j2
+++ b/docs/modules/druid/examples/getting_started/hdfs.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-hdfs
 spec:
   image:
-    productVersion: 3.4.1
+    productVersion: 3.4.2
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: simple-hdfs-znode

--- a/examples/psql/psql-hdfs-druid-cluster.yaml
+++ b/examples/psql/psql-hdfs-druid-cluster.yaml
@@ -33,7 +33,7 @@ metadata:
   name: simple-hdfs
 spec:
   image:
-    productVersion: 3.4.1
+    productVersion: 3.4.2
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: psql-druid-znode

--- a/examples/tls/tls-druid-cluster.yaml
+++ b/examples/tls/tls-druid-cluster.yaml
@@ -25,7 +25,7 @@ metadata:
   name: druid-hdfs
 spec:
   image:
-    productVersion: 3.4.1
+    productVersion: 3.4.2
   clusterConfig:
     dfsReplication: 1
     zookeeperConfigMapName: druid-hdfs-znode

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -34,10 +34,10 @@ dimensions:
       - 1.4.2
   - name: hadoop
     values:
-      - 3.4.1
+      - 3.4.2
   - name: hadoop-latest
     values:
-      - 3.4.1
+      - 3.4.2
   - name: s3-use-tls
     values:
       - "true"


### PR DESCRIPTION
## Description

Bump hadoop to 3.4.2 and run affected tests:

```
--- PASS: kuttl (1983.64s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/external-access_druid-34.0.0_zookeeper-latest-3.9.3_opa-1.4.2_hadoop-3.4.2_openshift-false (501.61s)
        --- PASS: kuttl/harness/authorizer_druid-34.0.0_zookeeper-latest-3.9.3_opa-1.4.2_hadoop-3.4.2_openshift-false (598.94s)
        --- PASS: kuttl/harness/ingestion-s3-ext_druid-latest-34.0.0_zookeeper-latest-3.9.3_hadoop-3.4.2_openshift-false (332.25s)
        --- PASS: kuttl/harness/logging_druid-34.0.0_zookeeper-latest-3.9.3_hadoop-3.4.2_openshift-false (323.60s)
        --- PASS: kuttl/harness/ldap_druid-34.0.0_zookeeper-latest-3.9.3_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (302.72s)
        --- PASS: kuttl/harness/overrides_druid-latest-34.0.0_zookeeper-latest-3.9.3_hadoop-latest-3.4.2_openshift-false (323.70s)
        --- PASS: kuttl/harness/smoke_druid-34.0.0_zookeeper-3.9.3_hadoop-3.4.2_openshift-false (251.03s)
        --- PASS: kuttl/harness/ingestion-no-s3-ext_druid-latest-34.0.0_zookeeper-latest-3.9.3_hadoop-3.4.2_openshift-false (334.80s)
        --- PASS: kuttl/harness/orphaned-resources_druid-latest-34.0.0_zookeeper-latest-3.9.3_hadoop-3.4.2_openshift-false (302.18s)
        --- PASS: kuttl/harness/cluster-operation_druid-latest-34.0.0_zookeeper-latest-3.9.3_hadoop-latest-3.4.2_openshift-false (326.94s)
        --- PASS: kuttl/harness/hdfs-deep-storage_druid-latest-34.0.0_zookeeper-latest-3.9.3_hadoop-3.4.2_openshift-false (293.22s)
PASS
```


## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
