### PR TITLE
chore: Bump zookeeper version for 25.11.0

### DIFF
--- a/docs/modules/druid/examples/getting_started/zookeeper.yaml
+++ b/docs/modules/druid/examples/getting_started/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/docs/modules/druid/examples/getting_started/zookeeper.yaml.j2
+++ b/docs/modules/druid/examples/getting_started/zookeeper.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/examples/psql-s3/psql-s3-druid-cluster.yaml
+++ b/examples/psql-s3/psql-s3-druid-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/examples/psql/psql-hdfs-druid-cluster.yaml
+++ b/examples/psql/psql-hdfs-druid-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/examples/tls/tls-druid-cluster.yaml
+++ b/examples/tls/tls-druid-cluster.yaml
@@ -5,7 +5,7 @@ metadata:
   name: druid-zk
 spec:
   image:
-    productVersion: 3.9.3
+    productVersion: 3.9.4
   servers:
     roleGroups:
       default:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -26,9 +26,10 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.3
+      - 3.9.4
   - name: zookeeper-latest
     values:
-      - 3.9.3
+      - 3.9.4
   - name: opa
     values:
       - 1.4.2


### PR DESCRIPTION
## Description

Part of https://github.com/stackabletech/docker-images/issues/1275

### Integrationtests

```
--- FAIL: kuttl (7901.80s)
    --- FAIL: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/ldap_druid-33.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-false_ldap-no-bind-credentials-false_openshift-false (401.25s)
        --- PASS: kuttl/harness/oidc_druid-30.0.1_zookeeper-latest-3.9.4_s3-use-tls-false_openshift-false_oidc-use-tls-false (506.42s)
        --- PASS: kuttl/harness/resources_druid-latest-34.0.0_zookeeper-latest-3.9.4_openshift-false (189.29s)
        --- PASS: kuttl/harness/orphaned-resources_druid-latest-34.0.0_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (475.79s)
        --- PASS: kuttl/harness/cluster-operation_druid-latest-34.0.0_zookeeper-latest-3.9.4_hadoop-latest-3.4.2_openshift-false (485.30s)
        --- PASS: kuttl/harness/logging_druid-34.0.0_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (244.85s)
        --- PASS: kuttl/harness/ingestion-no-s3-ext_druid-latest-34.0.0_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (354.70s)
        --- PASS: kuttl/harness/logging_druid-33.0.0_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (319.06s)
        --- PASS: kuttl/harness/logging_druid-30.0.1_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (323.88s)
        --- PASS: kuttl/harness/s3-deep-storage_druid-latest-34.0.0_zookeeper-latest-3.9.4_s3-use-tls-true_openshift-false (274.51s)
        --- PASS: kuttl/harness/overrides_druid-latest-34.0.0_zookeeper-latest-3.9.4_hadoop-latest-3.4.2_openshift-false (319.77s)
        --- PASS: kuttl/harness/s3-deep-storage_druid-latest-34.0.0_zookeeper-latest-3.9.4_s3-use-tls-false_openshift-false (299.15s)
        --- PASS: kuttl/harness/ingestion-s3-ext_druid-latest-34.0.0_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (303.69s)
        --- PASS: kuttl/harness/external-access_druid-34.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-3.4.2_openshift-false (291.11s)
        --- PASS: kuttl/harness/authorizer_druid-34.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-3.4.2_openshift-false (385.42s)
        --- PASS: kuttl/harness/authorizer_druid-33.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-3.4.2_openshift-false (344.42s)
        --- PASS: kuttl/harness/authorizer_druid-30.0.1_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-3.4.2_openshift-false (389.95s)
        --- PASS: kuttl/harness/hdfs-deep-storage_druid-latest-34.0.0_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (408.46s)
        --- PASS: kuttl/harness/smoke_druid-30.0.1_zookeeper-3.9.3_hadoop-3.4.2_openshift-false (268.51s)
        --- PASS: kuttl/harness/ldap_druid-30.0.1_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-false_ldap-no-bind-credentials-false_openshift-false (331.40s)
        --- FAIL: kuttl/harness/ldap_druid-30.0.1_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (526.03s)
        --- PASS: kuttl/harness/tls_druid-latest-34.0.0_zookeeper-latest-3.9.4_tls-mode-no-tls_openshift-false (416.60s)
        --- PASS: kuttl/harness/tls_druid-latest-34.0.0_zookeeper-latest-3.9.4_tls-mode-internal-and-server-tls_openshift-false (278.75s)
        --- PASS: kuttl/harness/tls_druid-latest-34.0.0_zookeeper-latest-3.9.4_tls-mode-internal-and-server-tls-and-tls-client-auth_openshift-false (280.82s)
        --- PASS: kuttl/harness/smoke_druid-34.0.0_zookeeper-3.9.4_hadoop-3.4.2_openshift-false (284.11s)
        --- PASS: kuttl/harness/smoke_druid-34.0.0_zookeeper-3.9.3_hadoop-3.4.2_openshift-false (285.28s)
        --- PASS: kuttl/harness/smoke_druid-33.0.0_zookeeper-3.9.4_hadoop-3.4.2_openshift-false (300.39s)
        --- PASS: kuttl/harness/smoke_druid-33.0.0_zookeeper-3.9.3_hadoop-3.4.2_openshift-false (286.37s)
        --- PASS: kuttl/harness/smoke_druid-30.0.1_zookeeper-3.9.4_hadoop-3.4.2_openshift-false (333.39s)
        --- PASS: kuttl/harness/oidc_druid-30.0.1_zookeeper-latest-3.9.4_s3-use-tls-true_openshift-false_oidc-use-tls-true (331.08s)
        --- PASS: kuttl/harness/oidc_druid-33.0.0_zookeeper-latest-3.9.4_s3-use-tls-false_openshift-false_oidc-use-tls-true (323.58s)
        --- PASS: kuttl/harness/oidc_druid-33.0.0_zookeeper-latest-3.9.4_s3-use-tls-false_openshift-false_oidc-use-tls-false (314.96s)
        --- PASS: kuttl/harness/oidc_druid-33.0.0_zookeeper-latest-3.9.4_s3-use-tls-true_openshift-false_oidc-use-tls-false (379.51s)
        --- PASS: kuttl/harness/ldap_druid-34.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (376.87s)
        --- FAIL: kuttl/harness/oidc_druid-34.0.0_zookeeper-latest-3.9.4_s3-use-tls-true_openshift-false_oidc-use-tls-true (683.45s)
        --- PASS: kuttl/harness/oidc_druid-34.0.0_zookeeper-latest-3.9.4_s3-use-tls-true_openshift-false_oidc-use-tls-false (378.75s)
        --- PASS: kuttl/harness/external-access_druid-33.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-3.4.2_openshift-false (311.22s)
        --- PASS: kuttl/harness/oidc_druid-34.0.0_zookeeper-latest-3.9.4_s3-use-tls-false_openshift-false_oidc-use-tls-true (337.32s)
        --- PASS: kuttl/harness/external-access_druid-30.0.1_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-3.4.2_openshift-false (281.30s)
        --- PASS: kuttl/harness/oidc_druid-34.0.0_zookeeper-latest-3.9.4_s3-use-tls-false_openshift-false_oidc-use-tls-false (376.18s)
        --- PASS: kuttl/harness/oidc_druid-30.0.1_zookeeper-latest-3.9.4_s3-use-tls-true_openshift-false_oidc-use-tls-false (346.84s)
        --- PASS: kuttl/harness/oidc_druid-33.0.0_zookeeper-latest-3.9.4_s3-use-tls-true_openshift-false_oidc-use-tls-true (304.88s)
        --- FAIL: kuttl/harness/ldap_druid-34.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-false_ldap-no-bind-credentials-false_openshift-false (364.34s)
        --- PASS: kuttl/harness/ldap_druid-33.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (350.42s)
        --- PASS: kuttl/harness/oidc_druid-30.0.1_zookeeper-latest-3.9.4_s3-use-tls-false_openshift-false_oidc-use-tls-true (361.01s)
FAIL

--- PASS: kuttl (1067.20s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/ldap_druid-33.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (271.84s)
        --- PASS: kuttl/harness/ldap_druid-30.0.1_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-false_ldap-no-bind-credentials-false_openshift-false (365.53s)
        --- PASS: kuttl/harness/ldap_druid-33.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-false_ldap-no-bind-credentials-false_openshift-false (365.04s)
        --- PASS: kuttl/harness/ldap_druid-34.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (349.95s)
        --- PASS: kuttl/harness/ldap_druid-34.0.0_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-false_ldap-no-bind-credentials-false_openshift-false (340.90s)
        --- PASS: kuttl/harness/ldap_druid-30.0.1_zookeeper-latest-3.9.4_opa-1.4.2_hadoop-latest-3.4.2_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (351.71s)
PASS

--- PASS: kuttl (348.00s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/oidc_druid-34.0.0_zookeeper-latest-3.9.4_s3-use-tls-true_openshift-false_oidc-use-tls-true (347.99s)
PASS
```

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [x] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
