### PR TITLE
chore: Bump vector to 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
   The `.clusterConfig.metadataStorageDatabase` has subfields according to the supported db types: `postgresql`, `mysql` and `derby`.
 - BREAKING: The `.clusterConfig.metadataStorageDatabase` field has been renamed to `.clusterConfig.metadataDatabase` for consistency ([#814]).
 - Document Helm deployed RBAC permissions and remove unnecessary permissions ([#810]).
+- test: Bump vector-aggregator to 0.55.0, replace /graphql call with gRPC calls ([#826]).
 
 ### Deleted
 
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 [#813]: https://github.com/stackabletech/druid-operator/pull/813
 [#814]: https://github.com/stackabletech/druid-operator/pull/814
 [#818]: https://github.com/stackabletech/druid-operator/pull/818
+[#826]: https://github.com/stackabletech/druid-operator/pull/826
 
 ## [26.3.0] - 2026-03-16
 

--- a/tests/templates/kuttl/logging/01-install-druid-vector-aggregator.yaml
+++ b/tests/templates/kuttl/logging/01-install-druid-vector-aggregator.yaml
@@ -5,7 +5,7 @@ commands:
   - script: >-
       helm install druid-vector-aggregator vector
       --namespace $NAMESPACE
-      --version 0.49.0
+      --version 0.52.0 `# app version 0.55.0`
       --repo https://helm.vector.dev
       --values 01_druid-vector-aggregator-values.yaml
 ---

--- a/tests/templates/kuttl/logging/test_log_aggregation.py
+++ b/tests/templates/kuttl/logging/test_log_aggregation.py
@@ -1,45 +1,40 @@
-#!/usr/bin/env python3
-import requests
+import json
+import subprocess
 
 
 def check_sent_events():
-    response = requests.post(
-        "http://druid-vector-aggregator:8686/graphql",
-        json={
-            "query": """
-                {
-                    transforms(first:100) {
-                        nodes {
-                            componentId
-                            metrics {
-                                sentEventsTotal {
-                                    sentEventsTotal
-                                }
-                            }
-                        }
-                    }
-                }
-            """
-        },
+    response = subprocess.run(
+        [
+            "grpcurl",
+            "-plaintext",
+            "-d",
+            '{"limit": 100}',
+            "druid-vector-aggregator:8686",
+            "vector.observability.v1.ObservabilityService/GetComponents",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,  # Raise a CalledProcessError if non-zero return
+        timeout=20,  # seconds
     )
+    result = json.loads(response.stdout)
+    components = result.get("components", [])
+    transforms = [
+        c for c in components if c.get("componentType") == "COMPONENT_TYPE_TRANSFORM"
+    ]
 
-    assert response.status_code == 200, (
-        "Cannot access the API of the vector aggregator."
-    )
+    assert len(transforms) > 0, "No transform components found"
 
-    result = response.json()
-
-    transforms = result["data"]["transforms"]["nodes"]
     for transform in transforms:
         sentEvents = transform["metrics"]["sentEventsTotal"]
         componentId = transform["componentId"]
 
         if componentId == "filteredInvalidEvents":
-            assert sentEvents is None or sentEvents["sentEventsTotal"] == 0, (
+            assert sentEvents is None or int(sentEvents) == 0, (
                 "Invalid log events were sent."
             )
         else:
-            assert sentEvents is not None and sentEvents["sentEventsTotal"] > 0, (
+            assert sentEvents is not None and int(sentEvents) > 0, (
                 f'No events were sent in "{componentId}".'
             )
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -73,7 +73,7 @@ tests:
     dimensions:
       - druid
       - zookeeper-latest
-      - opa
+      - opa-latest
       - hadoop
       - openshift
   - name: ingestion-no-s3-ext


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1486

```
--- PASS: kuttl (975.31s)
    --- PASS: kuttl/harness (0.00s)
        --- PASS: kuttl/harness/logging_druid-30.0.1_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (388.17s)
        --- PASS: kuttl/harness/logging_druid-35.0.1_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (288.09s)
        --- PASS: kuttl/harness/logging_druid-34.0.0_zookeeper-latest-3.9.4_hadoop-3.4.2_openshift-false (299.02s)
PASS
```