### PR TITLE
chore: Bump ZooKeeper version to 3.9.5 for SDP 26.7.0

### DIFF
--- a/docs/modules/druid/examples/getting_started/zookeeper.yaml
+++ b/docs/modules/druid/examples/getting_started/zookeeper.yaml
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   servers:
     roleGroups:
       default:

--- a/docs/modules/druid/examples/getting_started/zookeeper.yaml.j2
+++ b/docs/modules/druid/examples/getting_started/zookeeper.yaml.j2
@@ -5,7 +5,7 @@ metadata:
   name: simple-zk
 spec:
   image:
-    productVersion: 3.9.4
+    productVersion: 3.9.5
   servers:
     roleGroups:
       default:

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -26,9 +26,10 @@ dimensions:
   - name: zookeeper
     values:
       - 3.9.4
+      - 3.9.5
   - name: zookeeper-latest
     values:
-      - 3.9.4
+      - 3.9.5
   - name: opa-latest
     values:
       - 1.16.2


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1506.