### PR TITLE
chore: Bump Rust edition to 2024

### DIFF
--- a/Cargo.nix
+++ b/Cargo.nix
@@ -9780,7 +9780,7 @@ rec {
       "stackable-druid-operator" = rec {
         crateName = "stackable-druid-operator";
         version = "0.0.0-dev";
-        edition = "2021";
+        edition = "2024";
         crateBin = [
           {
             name = "stackable-druid-operator";

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ resolver = "2"
 version = "0.0.0-dev"
 authors = ["Stackable GmbH <info@stackable.tech>"]
 license = "OSL-3.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/stackabletech/druid-operator"
 
 [workspace.dependencies]

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -493,46 +493,46 @@ pub async fn reconcile_druid(
             );
         }
 
-        if let Some(listener_class) = druid_role.listener_class_name(druid) {
-            if let Some(listener_group_name) = group_listener_name(druid, &druid_role) {
-                let role_group_listener = build_group_listener(
+        if let Some(listener_class) = druid_role.listener_class_name(druid)
+            && let Some(listener_group_name) = group_listener_name(druid, &druid_role)
+        {
+            let role_group_listener = build_group_listener(
+                druid,
+                build_recommended_labels(
                     druid,
-                    build_recommended_labels(
-                        druid,
-                        DRUID_CONTROLLER_NAME,
-                        &validated.resolved_product_image.app_version_label_value,
-                        role_name,
-                        "none",
-                    ),
-                    listener_class.to_string(),
-                    listener_group_name,
-                    &druid_role,
+                    DRUID_CONTROLLER_NAME,
+                    &validated.resolved_product_image.app_version_label_value,
+                    role_name,
+                    "none",
+                ),
+                listener_class.to_string(),
+                listener_group_name,
+                &druid_role,
+                &validated.druid_tls_security,
+            )
+            .context(ListenerConfigurationSnafu)?;
+
+            let listener = cluster_resources
+                .add(client, role_group_listener)
+                .await
+                .context(ApplyGroupListenerSnafu)?;
+
+            if druid_role == DruidRole::Router {
+                // discovery
+                for discovery_cm in build_discovery_configmaps(
+                    druid,
+                    druid,
+                    &validated.resolved_product_image,
                     &validated.druid_tls_security,
+                    listener,
                 )
-                .context(ListenerConfigurationSnafu)?;
-
-                let listener = cluster_resources
-                    .add(client, role_group_listener)
-                    .await
-                    .context(ApplyGroupListenerSnafu)?;
-
-                if druid_role == DruidRole::Router {
-                    // discovery
-                    for discovery_cm in build_discovery_configmaps(
-                        druid,
-                        druid,
-                        &validated.resolved_product_image,
-                        &validated.druid_tls_security,
-                        listener,
-                    )
-                    .await
-                    .context(BuildDiscoveryConfigSnafu)?
-                    {
-                        cluster_resources
-                            .add(client, discovery_cm)
-                            .await
-                            .context(ApplyDiscoveryConfigSnafu)?;
-                    }
+                .await
+                .context(BuildDiscoveryConfigSnafu)?
+                {
+                    cluster_resources
+                        .add(client, discovery_cm)
+                        .await
+                        .context(ApplyDiscoveryConfigSnafu)?;
                 }
             }
         }

--- a/rust/operator-binary/src/crd/authentication.rs
+++ b/rust/operator-binary/src/crd/authentication.rs
@@ -139,10 +139,9 @@ impl AuthenticationClassesResolved {
                         Some(server_and_internal_secret_class) => {
                             if let Some(auth_class_secret_class) =
                                 &provider.client_cert_secret_class
+                                && auth_class_secret_class != server_and_internal_secret_class
                             {
-                                if auth_class_secret_class != server_and_internal_secret_class {
-                                    return TlsAuthenticationClassSecretClassDiffersFromDruidServerTlsSnafu { auth_class_name: auth_class_name.to_string(), server_and_internal_secret_class: server_and_internal_secret_class.clone() }.fail()?;
-                                }
+                                return TlsAuthenticationClassSecretClassDiffersFromDruidServerTlsSnafu { auth_class_name: auth_class_name.to_string(), server_and_internal_secret_class: server_and_internal_secret_class.clone() }.fail()?;
                             }
                         }
                         None => {
@@ -231,10 +230,10 @@ impl AuthenticationClassesResolved {
     }
 
     pub fn tls_authentication_enabled(&self) -> bool {
-        if !self.auth_classes.is_empty() {
-            if let Some(AuthenticationClassResolved::Tls { .. }) = self.auth_classes.first() {
-                return true;
-            }
+        if !self.auth_classes.is_empty()
+            && let Some(AuthenticationClassResolved::Tls { .. }) = self.auth_classes.first()
+        {
+            return true;
         }
         false
     }

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -457,7 +457,7 @@ impl v1alpha1::DruidCluster {
         (
             Vec<PropertyNameKind>,
             Role<
-                impl Configuration<Configurable = v1alpha1::DruidCluster>,
+                impl Configuration<Configurable = v1alpha1::DruidCluster> + use<>,
                 DruidConfigOverrides,
                 GenericRoleConfig,
                 JavaCommonConfig,
@@ -725,7 +725,7 @@ impl v1alpha1::DruidCluster {
         &self,
         druid_role: &DruidRole,
     ) -> Role<
-        impl Configuration<Configurable = v1alpha1::DruidCluster>,
+        impl Configuration<Configurable = v1alpha1::DruidCluster> + use<>,
         DruidConfigOverrides,
         GenericRoleConfig,
         JavaCommonConfig,
@@ -1043,10 +1043,10 @@ impl DruidRole {
     ) -> Vec<String> {
         let mut commands = vec![];
 
-        if let Some(s3) = s3 {
-            if let Some(ca_cert_file) = s3.tls.tls_ca_cert_mount_path() {
-                commands.extend(add_cert_to_jvm_trust_store_cmd(&ca_cert_file));
-            }
+        if let Some(s3) = s3
+            && let Some(ca_cert_file) = s3.tls.tls_ca_cert_mount_path()
+        {
+            commands.extend(add_cert_to_jvm_trust_store_cmd(&ca_cert_file));
         }
 
         // copy druid config to rw config

--- a/rust/operator-binary/src/webhooks/conversion.rs
+++ b/rust/operator-binary/src/webhooks/conversion.rs
@@ -37,7 +37,7 @@ pub async fn create_webhook_server(
         field_manager: FIELD_MANAGER.to_owned(),
     };
 
-    let (conversion_webhook, _initial_reconcile_rx) =
+    let (conversion_webhook, _) =
         ConversionWebhook::new(crds_and_handlers, client, conversion_webhook_options);
 
     let webhook_server_options = WebhookServerOptions {


### PR DESCRIPTION
Run `cargo fix --edition` and resolve resulting warnings:

- Add `use<>` syntax to `impl Trait` return types (auto-fixed)
- Fix temporary drop order change in Rust 2024 by explicitly dropping `_initial_reconcile_rx`

+ Fixing format on a few files to pass fmt

Part of https://github.com/stackabletech/issues/issues/832

## Description

*Please add a description here. This will become the commit message of the merge request later.*

## Definition of Done Checklist

- Not all of these items are applicable to all PRs, the author should update this template to only leave the boxes in that are relevant
- Please make sure all these things are done and tick the boxes

### Author

- [ ] Changes are OpenShift compatible
- [ ] CRD changes approved
- [ ] CRD documentation for all fields, following the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Helm chart can be installed and deployed operator works
- [ ] Integration tests passed (for non trivial changes)
- [ ] Changes need to be "offline" compatible
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added

### Reviewer

- [ ] Code contains useful comments
- [ ] Code contains useful logging statements
- [ ] (Integration-)Test cases added
- [ ] Documentation added or updated. Follows the [style guide](https://docs.stackable.tech/home/nightly/contributor/docs/style-guide).
- [ ] Changelog updated
- [ ] Cargo.toml only contains references to git tags (not specific commits or branches)

### Acceptance

- [ ] Feature Tracker has been updated
- [ ] Proper release label has been added
- [ ] Links to generated (nightly) docs added
- [ ] Release note snippet added
- [ ] Add `type/deprecation` label & add to the [deprecation schedule](https://github.com/orgs/stackabletech/projects/44/views/1)
- [ ] Add `type/experimental` label & add to the [experimental features tracker](https://github.com/orgs/stackabletech/projects/47)
