### PR TITLE
Druid 37.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - BREAKING: Add required CLI argument and env var to set the image repository used to construct final product image names: `IMAGE_REPOSITORY` (`--image-repository`), eg. `oci.example.org/my/namespace` ([#818]).
-- Add support OIDC `clientAuthenticationMethod` configuration ([#813]).
+- Add support for OIDC `clientAuthenticationMethod` configuration ([#813]).
 - Add support for Druid 37.0.0 ([#832]).
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - BREAKING: Add required CLI argument and env var to set the image repository used to construct final product image names: `IMAGE_REPOSITORY` (`--image-repository`), eg. `oci.example.org/my/namespace` ([#818]).
-- Support OIDC `clientAuthenticationMethod` configuration ([#813]).
+- Add support OIDC `clientAuthenticationMethod` configuration ([#813]).
+- Add support for Druid 37.0.0 ([#832]).
 
 ### Changed
 
@@ -21,7 +22,8 @@ All notable changes to this project will be documented in this file.
 
 ### Deleted
 
-- Removed all metadata storage related properties from product config ([#814]).
+- Remove all metadata storage related properties from product config ([#814]).
+- Remove support for Druid 34.0.0 ([#832]).
 
 [#810]: https://github.com/stackabletech/druid-operator/pull/810
 [#813]: https://github.com/stackabletech/druid-operator/pull/813
@@ -29,6 +31,7 @@ All notable changes to this project will be documented in this file.
 [#818]: https://github.com/stackabletech/druid-operator/pull/818
 [#824]: https://github.com/stackabletech/druid-operator/pull/824
 [#826]: https://github.com/stackabletech/druid-operator/pull/826
+[#832]: https://github.com/stackabletech/druid-operator/pull/832
 
 ## [26.3.0] - 2026-03-16
 

--- a/docs/modules/druid/partials/supported-versions.adoc
+++ b/docs/modules/druid/partials/supported-versions.adoc
@@ -2,6 +2,6 @@
 // This is a separate file, since it is used by both the direct Druid documentation, and the overarching
 // Stackable Platform documentation.
 
-- 35.0.1
-- 34.0.0 (deprecated)
-- 30.0.1 (LTS)
+- 37.0.0 (LTS)
+- 35.0.1 (Deprecated)
+- 30.0.1 (Deprecated)

--- a/rust/operator-binary/src/config/jvm.rs
+++ b/rust/operator-binary/src/config/jvm.rs
@@ -1,12 +1,13 @@
+use semver::Version;
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
+    crd::s3::v1alpha1::ConnectionSpec,
     memory::MemoryQuantity,
-    role_utils,
-    role_utils::{GenericRoleConfig, JavaCommonConfig, JvmArgumentOverrides, Role},
+    role_utils::{self, GenericRoleConfig, JavaCommonConfig, JvmArgumentOverrides, Role},
 };
 
 use crate::crd::{
-    DruidConfigOverrides, DruidRole, JVM_SECURITY_PROPERTIES_FILE, LOG4J2_CONFIG,
+    AWS_REGION, DruidConfigOverrides, DruidRole, JVM_SECURITY_PROPERTIES_FILE, LOG4J2_CONFIG,
     RW_CONFIG_DIRECTORY, STACKABLE_TRUST_STORE, STACKABLE_TRUST_STORE_PASSWORD,
 };
 
@@ -30,6 +31,9 @@ pub fn construct_jvm_args<T>(
     role_group: &str,
     heap: MemoryQuantity,
     direct_memory: Option<MemoryQuantity>,
+    s3_conn: Option<&ConnectionSpec>,
+    // TODO (@NickLarsenNZ): Remove this once we don't support Druid less than 37.0.0
+    druid_version: Result<Version, semver::Error>,
 ) -> Result<String, Error> {
     let heap_str = heap
         .format_for_java()
@@ -66,6 +70,18 @@ pub fn construct_jvm_args<T>(
     ]);
     if druid_role == &DruidRole::Coordinator {
         jvm_args.push("-Dderby.stream.error.file=/stackable/var/druid/derby.log".to_owned());
+    }
+    // TODO (@NickLarsenNZ): Remove the condition (keep the body) once we no longer support Druid
+    // less than 37.0.0
+    // Druid >= 37.0.0 uses the AWS SDK v2, which requires a region to be set via the JVM system
+    // property `aws.region`.
+    if matches!(&druid_version, Ok(v) if *v >= Version::new(37, 0, 0))
+        && let Some(s3) = s3_conn
+    {
+        jvm_args.push(format!(
+            "-D{AWS_REGION}={region_name}",
+            region_name = s3.region.name
+        ));
     }
 
     let operator_generated = JvmArgumentOverrides::new_with_only_additions(jvm_args);
@@ -299,6 +315,15 @@ mod tests {
             .get_memory_sizes(druid_role)
             .unwrap();
 
-        construct_jvm_args(druid_role, &role, "default", heap, direct).unwrap()
+        construct_jvm_args(
+            druid_role,
+            &role,
+            "default",
+            heap,
+            direct,
+            None,
+            semver::Version::parse("37.0.0"),
+        )
+        .unwrap()
     }
 }

--- a/rust/operator-binary/src/controller.rs
+++ b/rust/operator-binary/src/controller.rs
@@ -13,6 +13,7 @@ use product_config::{
     types::PropertyNameKind,
     writer::{PropertiesWriterError, to_java_properties_string},
 };
+use semver::Version;
 use snafu::{ResultExt, Snafu};
 use stackable_operator::{
     builder::{
@@ -66,13 +67,15 @@ use crate::{
     authentication::DruidAuthenticationConfig,
     config::jvm::construct_jvm_args,
     crd::{
-        APP_NAME, AUTH_AUTHORIZER_OPA_URI, CommonRoleGroupConfig, Container,
+        APP_NAME, AUTH_AUTHORIZER_OPA_URI, AWS_REGION, CommonRoleGroupConfig, Container,
         DRUID_CONFIG_DIRECTORY, DS_BUCKET, DeepStorageSpec, DruidClusterStatus, DruidRole,
-        EXTENSIONS_LOADLIST, HDFS_CONFIG_DIRECTORY, JVM_CONFIG, JVM_SECURITY_PROPERTIES_FILE,
-        LOG_CONFIG_DIRECTORY, MAX_DRUID_LOG_FILES_SIZE, METRICS_PORT, METRICS_PORT_NAME,
-        OPERATOR_NAME, RUNTIME_PROPS, RW_CONFIG_DIRECTORY, S3_ACCESS_KEY, S3_ENDPOINT_URL,
-        S3_PATH_STYLE_ACCESS, S3_SECRET_KEY, STACKABLE_LOG_DIR, ZOOKEEPER_CONNECTION_STRING,
-        build_recommended_labels, build_string_list, security::DruidTlsSecurity, v1alpha1,
+        EXTENSIONS_LOADLIST, HDFS_CONFIG_DIRECTORY, INDEXER_JAVA_OPTS, JVM_CONFIG,
+        JVM_SECURITY_PROPERTIES_FILE, LOG_CONFIG_DIRECTORY, MAX_DRUID_LOG_FILES_SIZE, METRICS_PORT,
+        METRICS_PORT_NAME, OPERATOR_NAME, RUNTIME_PROPS, RW_CONFIG_DIRECTORY, S3_ACCESS_KEY,
+        S3_ENDPOINT_URL, S3_PATH_STYLE_ACCESS, S3_SECRET_KEY, S3_USE_TRANSFER_MANAGER,
+        STACKABLE_LOG_DIR, STACKABLE_TRUST_STORE, STACKABLE_TRUST_STORE_PASSWORD,
+        ZOOKEEPER_CONNECTION_STRING, build_recommended_labels, build_string_list,
+        security::DruidTlsSecurity, v1alpha1,
     },
     discovery::{self, build_discovery_configmaps},
     extensions::get_extension_list,
@@ -678,15 +681,42 @@ fn build_rolegroup_config_map(
                 }
 
                 if let Some(s3) = s3_conn {
-                    if !s3.region.is_default_config() {
-                        // Raising this as warning instead of returning an error, better safe than sorry.
-                        // It might still work out for the user.
-                        tracing::warn!(
-                            region = ?s3.region,
-                            "You configured a non-default region on the S3Connection.
-                            The S3Connection region field is ignored because Druid uses the AWS SDK v1, which ignores the region if the endpoint is set. \
-                            The host is a required field, therefore the endpoint will always be set."
-                        )
+                    // TODO (@NickLarsenNZ): Remove the version condition once we no longer support
+                    // Druid less than 37.0.0.
+                    // Druid >= 37.0.0 uses the AWS SDK v2, which requires a region. Older versions
+                    // use the AWS SDK v1, which ignores the region when an endpoint is set (and the
+                    // endpoint is always set because `host` is a required field on S3Connection).
+                    let druid_version = Version::parse(&resolved_product_image.product_version);
+                    match &druid_version {
+                        Ok(v) if *v < Version::new(37, 0, 0) => {
+                            if !s3.region.is_default_config() {
+                                tracing::warn!(
+                                    region = ?s3.region,
+                                    "You configured a non-default region on the S3Connection. \
+                                    The S3Connection region field is ignored because this Druid version \
+                                    uses the AWS SDK v1, which ignores the region if the endpoint is set. \
+                                    The host is a required field, therefore the endpoint will always be set."
+                                );
+                            }
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                %err,
+                                version = %resolved_product_image.product_version,
+                                "Failed to parse Druid product version, skipping S3 region configuration"
+                            );
+                        }
+                        // For Druid >= 37.0.0, region is set via JVM system property
+                        // `-Daws.region` in the JVM_CONFIG section below.
+                        Ok(_) => {
+                            // Disable the S3 Transfer Manager to avoid the AWS
+                            // CRT async HTTP client, which fails with non-AWS
+                            // S3 endpoints. See S3_TRANSFER_MANAGER_ENABLED.
+                            conf.insert(
+                                S3_USE_TRANSFER_MANAGER.to_string(),
+                                Some("false".to_string()),
+                            );
+                        }
                     }
 
                     conf.insert(
@@ -733,6 +763,34 @@ fn build_rolegroup_config_map(
                 // extend the config to respect overrides
                 conf.extend(transformed_config);
 
+                // Build javaOptsArray for Middle Manager Peon workers.
+                // These JVM opts are passed to Peon processes spawned by the
+                // Middle Manager.
+                if druid_role == DruidRole::MiddleManager {
+                    let mut peon_java_opts = vec![
+                        format!("-Djavax.net.ssl.trustStore={STACKABLE_TRUST_STORE}"),
+                        format!(
+                            "-Djavax.net.ssl.trustStorePassword={STACKABLE_TRUST_STORE_PASSWORD}"
+                        ),
+                        "-Djavax.net.ssl.trustStoreType=pkcs12".to_owned(),
+                    ];
+
+                    if let Some(s3) = s3_conn {
+                        let druid_version = Version::parse(&resolved_product_image.product_version);
+                        if matches!(&druid_version, Ok(v) if *v >= Version::new(37, 0, 0)) {
+                            peon_java_opts.push(format!(
+                                "-D{AWS_REGION}={region_name}",
+                                region_name = s3.region.name,
+                            ));
+                        }
+                    }
+
+                    conf.insert(
+                        INDEXER_JAVA_OPTS.to_string(),
+                        Some(build_string_list(&peon_java_opts)),
+                    );
+                }
+
                 let runtime_properties =
                     to_java_properties_string(conf.iter()).context(PropertiesWriteSnafu)?;
                 cm_conf_data.insert(RUNTIME_PROPS.to_string(), runtime_properties);
@@ -743,9 +801,19 @@ fn build_rolegroup_config_map(
                     .resources
                     .get_memory_sizes(&druid_role)
                     .context(DeriveMemorySettingsSnafu)?;
-                let jvm_config =
-                    construct_jvm_args(&druid_role, &role, &rolegroup.role_group, heap, direct)
-                        .context(GetJvmConfigSnafu)?;
+                // TODO (@NickLarsenNZ): Remove this once we don't support Druid less than 37.0.0
+                let druid_version = Version::parse(&resolved_product_image.product_version);
+                let jvm_config = construct_jvm_args(
+                    &druid_role,
+                    &role,
+                    &rolegroup.role_group,
+                    heap,
+                    direct,
+                    s3_conn,
+                    druid_version,
+                )
+                .context(GetJvmConfigSnafu)?;
+
                 cm_conf_data.insert(JVM_CONFIG.to_string(), jvm_config);
             }
 

--- a/rust/operator-binary/src/crd/mod.rs
+++ b/rust/operator-binary/src/crd/mod.rs
@@ -105,6 +105,10 @@ pub const S3_ENDPOINT_URL: &str = "druid.s3.endpoint.url";
 pub const S3_ACCESS_KEY: &str = "druid.s3.accessKey";
 pub const S3_SECRET_KEY: &str = "druid.s3.secretKey";
 pub const S3_PATH_STYLE_ACCESS: &str = "druid.s3.enablePathStyleAccess";
+pub const S3_USE_TRANSFER_MANAGER: &str = "druid.storage.transfer.useTransferManager";
+/// AWS Region JVM System Property, passed to AWS SDK v2.
+/// See: https://druid.apache.org/docs/latest/development/extensions-core/s3/#aws-region
+pub const AWS_REGION: &str = "aws.region";
 // OPA
 pub const AUTH_AUTHORIZERS: &str = "druid.auth.authorizers";
 pub const AUTH_AUTHORIZERS_VALUE: &str = "[\"OpaAuthorizer\"]";
@@ -1534,16 +1538,7 @@ impl Configuration for MiddleManagerConfigFragment {
         _role_name: &str,
         file: &str,
     ) -> Result<BTreeMap<String, Option<String>>, ConfigError> {
-        let mut result = resource.common_compute_files(file)?;
-        result.insert(
-            INDEXER_JAVA_OPTS.to_string(),
-            Some(build_string_list(&[
-                format!("-Djavax.net.ssl.trustStore={STACKABLE_TRUST_STORE}"),
-                format!("-Djavax.net.ssl.trustStorePassword={STACKABLE_TRUST_STORE_PASSWORD}"),
-                "-Djavax.net.ssl.trustStoreType=pkcs12".to_owned(),
-            ])),
-        );
-        Ok(result)
+        resource.common_compute_files(file)
     }
 }
 

--- a/tests/test-definition.yaml
+++ b/tests/test-definition.yaml
@@ -14,13 +14,13 @@ dimensions:
   - name: druid
     values:
       - 30.0.1
-      - 34.0.0
       - 35.0.1
+      - 37.0.0
       # To use a custom image, add a comma and the full name after the product version
       # - 30.0.0,oci.stackable.tech/sdp/druid:30.0.0-stackable0.0.0-dev
   - name: druid-latest
     values:
-      - 35.0.1
+      - 37.0.0
       # To use a custom image, add a comma and the full name after the product version
       # - 30.0.0,oci.stackable.tech/sdp/druid:30.0.0-stackable0.0.0-dev
   - name: zookeeper
@@ -42,7 +42,9 @@ dimensions:
   - name: s3-use-tls
     values:
       - "true"
-      - "false"
+      # Druid >= 37.0.0 (AWS SDK v2) does not support non-TLS S3 endpoints
+      # due to SigV4 signing mismatches over HTTP.
+      # - "false"
   - name: tls-mode
     values:
       - "no-tls"


### PR DESCRIPTION
Part of https://github.com/stackabletech/docker-images/issues/1490

> [!NOTE]
> Druid 37.0.0 doesn't support non-TLS S3 connections, so we drop the non-TLS tests.

<details><summary>Tests pass</summary>

```
--- PASS: kuttl/harness/tls_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_tls-mode-no-tls_openshift-false (164.94s)
--- PASS: kuttl/harness/tls_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_tls-mode-internal-and-server-tls-and-tls-client-auth_openshift-false (233.06s)
--- PASS: kuttl/harness/tls_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_tls-mode-internal-and-server-tls_openshift-false (187.16s)
--- PASS: kuttl/harness/smoke_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-3.9.5_hadoop-3.4.2_openshift-false (246.86s)
--- PASS: kuttl/harness/smoke_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-3.9.4_hadoop-3.4.2_openshift-false (312.00s)
--- PASS: kuttl/harness/s3-deep-storage_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_s3-use-tls-true_openshift-false (187.07s)
--- PASS: kuttl/harness/resources_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_openshift-false (133.95s)
--- PASS: kuttl/harness/overrides_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_hadoop-latest-3.4.2_openshift-false (287.53s)
--- PASS: kuttl/harness/orphaned-resources_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_hadoop-3.4.2_openshift-false (299.57s)
--- PASS: kuttl/harness/oidc_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_s3-use-tls-true_openshift-false_oidc-use-tls-true (268.33s)
--- PASS: kuttl/harness/oidc_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_s3-use-tls-true_openshift-false_oidc-use-tls-false (199.17s)
--- PASS: kuttl/harness/logging_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_hadoop-3.4.2_openshift-false (225.25s)
--- PASS: kuttl/harness/ldap_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_opa-latest-1.16.2_hadoop-latest-3.4.2_ldap-use-tls-true_ldap-no-bind-credentials-false_openshift-false (266.27s)
--- PASS: kuttl/harness/ldap_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_opa-latest-1.16.2_hadoop-latest-3.4.2_ldap-use-tls-false_ldap-no-bind-credentials-false_openshift-false (291.84s)
--- PASS: kuttl/harness/ingestion-s3-ext_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_hadoop-3.4.2_openshift-false (309.26s)
--- PASS: kuttl/harness/ingestion-no-s3-ext_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_hadoop-3.4.2_openshift-false (297.53s)
--- PASS: kuttl/harness/hdfs-deep-storage_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_hadoop-3.4.2_openshift-false (336.26s)
--- PASS: kuttl/harness/external-access_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_hadoop-3.4.2_openshift-false (252.40s)
--- PASS: kuttl/harness/cluster-operation_druid-latest-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_hadoop-latest-3.4.2_openshift-false (306.55s)
--- PASS: kuttl/harness/authorizer_druid-37.0.0,oci.stackable.tech_sdp_druid_37.0.0-stackable0.0.0-dev_zookeeper-latest-3.9.5_opa-latest-1.16.2_hadoop-3.4.2_openshift-false (262.84s)
```

</details>