### PR TITLE
docs: crds are installed by the operator

### DIFF
--- a/docs/modules/druid/pages/getting_started/installation.adoc
+++ b/docs/modules/druid/pages/getting_started/installation.adoc
@@ -42,7 +42,8 @@ NOTE: `helm repo` subcommands are not supported for OCI registries. The operator
 include::example$getting_started/getting_started.sh[tag=helm-install-operators]
 ----
 
-Helm deploys the operators in a Kubernetes Deployment and applies the CRDs for the Apache Druid service (as well as the CRDs for the required operators).
+Helm deploys the operators in a Kubernetes Deployment.
+Each operator installs and maintains its own CRDs at startup (see xref:concepts:maintenance/crds.adoc[]).
 --
 ====
 


### PR DESCRIPTION
## Description

As of 26.3 all operators manage their CRDs - this was not unambiguously reflected in the docs.
