### PR TITLE
docs: Deprecate Apache Druid

### DIFF
--- a/.readme/partials/main.md.j2
+++ b/.readme/partials/main.md.j2
@@ -1,3 +1,10 @@
+> [!WARNING]
+> **Stackable support for Apache Druid is deprecated and will be removed from the Stackable Data Platform (SDP).**
+> This concerns only the Apache Druid integration in the SDP (this operator); Apache Druid itself is an independent, actively maintained project and is not affected.
+> Stackable's support is deprecated as of SDP 26.7 and is planned for removal in SDP 27.11; SDP 27.7 is planned to be the last release that includes it.
+> We have taken this decision because we have not seen adoption of Apache Druid among our customers.
+> There is no direct replacement within the SDP. If you rely on this integration — or would be willing to fund its continued development — please contact us via our [homepage](https://stackable.tech/) or the [Discussions forum](https://github.com/orgs/stackabletech/discussions).
+
 This is a Kubernetes operator to manage [Apache Druid](https://druid.apache.org/) ensembles.
 
 {% filter trim %}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ All notable changes to this project will be documented in this file.
 - BREAKING: Removed product-config machinery. This is a breaking change in terms of configuration.
   Users relying on the product-config `properties.yaml` file have to set these properties via the CRD ([#830]).
 
+### Deprecated
+
+- Stackable's support for Apache Druid is deprecated and is planned for removal from the SDP in SDP 27.11.
+  This concerns only the Apache Druid integration in the SDP (this operator); Apache Druid itself is not affected.
+  SDP 27.7 is planned to be the last release that includes Apache Druid.
+  We have not seen adoption of Apache Druid among our customers; if you rely on it, please [contact us](https://stackable.tech/) ([#853]).
+
 ### Deleted
 
 - Remove all metadata storage related properties from product config ([#814]).
@@ -41,6 +48,7 @@ All notable changes to this project will be documented in this file.
 [#830]: https://github.com/stackabletech/druid-operator/pull/830
 [#832]: https://github.com/stackabletech/druid-operator/pull/832
 [#840]: https://github.com/stackabletech/druid-operator/pull/840
+[#853]: https://github.com/stackabletech/druid-operator/pull/853
 
 ## [26.3.0] - 2026-03-16
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 
 [Documentation](https://docs.stackable.tech/home/stable/druid) | [Stackable Data Platform](https://stackable.tech/) | [Platform Docs](https://docs.stackable.tech/) | [Discussions](https://github.com/orgs/stackabletech/discussions) | [Discord](https://discord.gg/7kZ3BNnCAF)
 
+> [!WARNING]
+> **Stackable support for Apache Druid is deprecated and will be removed from the Stackable Data Platform (SDP).**
+> This concerns only the Apache Druid integration in the SDP (this operator); Apache Druid itself is an independent, actively maintained project and is not affected.
+> Stackable's support is deprecated as of SDP 26.7 and is planned for removal in SDP 27.11; SDP 27.7 is planned to be the last release that includes it.
+> We have taken this decision because we have not seen adoption of Apache Druid among our customers.
+> There is no direct replacement within the SDP. If you rely on this integration — or would be willing to fund its continued development — please contact us via our [homepage](https://stackable.tech/) or the [Discussions forum](https://github.com/orgs/stackabletech/discussions).
+
 This is a Kubernetes operator to manage [Apache Druid](https://druid.apache.org/) ensembles.
 
 <!-- markdownlint-disable MD041 MD051 -->

--- a/docs/modules/druid/pages/index.adoc
+++ b/docs/modules/druid/pages/index.adoc
@@ -15,6 +15,25 @@
 * {feature-tracker}[Feature Tracker {external-link-icon}^]
 * {crd}[CRD documentation {external-link-icon}^]
 
+[WARNING]
+.Stackable support for Apache Druid is deprecated
+====
+Stackable's support for Apache Druid is deprecated as of SDP 26.7 and is planned for removal in SDP 27.11.
+This concerns only the Apache Druid integration in the Stackable Data Platform (SDP) — that is, this operator.
+Apache Druid itself is an independent, actively maintained project and is not affected; only its inclusion in the SDP is being discontinued.
+We have taken this decision because we have not seen adoption of Apache Druid among our customers.
+
+The planned timeline is:
+
+* SDP 26.7 ships Apache Druid 37.0.0, the final LTS version we plan to provide, with approximately one year of support.
+* SDP 27.7 is planned to be the last release that includes Apache Druid.
+* Apache Druid is planned to be removed in SDP 27.11.
+
+There is no direct replacement for Apache Druid within the SDP.
+If you rely on Apache Druid, please contact us via our https://stackable.tech/[homepage] or the https://github.com/orgs/stackabletech/discussions[Discussions forum] to discuss your options.
+If you are willing to fund its continued development and support, we are open to reconsidering this decision.
+====
+
 The Stackable operator for Apache Druid deploys and manages {druid}[Apache Druid] clusters on Kubernetes.
 Apache Druid is an open-source, distributed data store designed to quickly process large amounts of data in real-time.
 It enables users to ingest, store, and query massive amounts of data in real-time, a great tool for handling high-volume data processing and analysis.

--- a/docs/modules/druid/partials/supported-versions.adoc
+++ b/docs/modules/druid/partials/supported-versions.adoc
@@ -2,6 +2,13 @@
 // This is a separate file, since it is used by both the direct Druid documentation, and the overarching
 // Stackable Platform documentation.
 
+[NOTE]
+====
+Stackable's support for Apache Druid is deprecated and is planned for removal from the SDP in SDP 27.11.
+The last SDP release to include Apache Druid is planned to be 27.7.
+Apache Druid itself is not affected; only its inclusion in the SDP is being discontinued.
+====
+
 - 37.0.0 (LTS)
 - 35.0.1 (Deprecated)
 - 30.0.1 (Deprecated)


### PR DESCRIPTION
Backport of #853 onto `release-26.7`.

Cherry-pick of the squashed commit `23ee57f`